### PR TITLE
Marks the IonInputFormat as not splittable, meaning that Ion files will not be split into arbitrarily-sized chunks.

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/formats/IonInputFormat.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/formats/IonInputFormat.java
@@ -46,6 +46,11 @@ public class IonInputFormat extends FileInputFormat {
     private static final Log LOG = LogFactory.getLog(IonInputFormat.class);
 
     @Override
+    protected boolean isSplitable(final FileSystem fs, final Path filename) {
+        return false;
+    }
+
+    @Override
     public RecordReader getRecordReader(final InputSplit split, final JobConf job, final Reporter reporter)
         throws IOException {
 


### PR DESCRIPTION
Without additional logic (which is possible to write, but is currently not written) to ensure each chunk contains
a self-contained symbol table context, splitting Ion files will cause errors on read.

*Issue #, if available:*
#47 

*Description of changes:*
From the documentation for [`FileInputFormat.isSplitable`](https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/mapred/FileInputFormat.html#isSplitable-org.apache.hadoop.fs.FileSystem-org.apache.hadoop.fs.Path-):

> Implementations that may deal with non-splittable files must override this method. FileInputFormat implementations can override this and return false to ensure that individual input files are never split-up so that Mappers process entire files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
