### PR TITLE
Fix Case_Sensitive Property

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
@@ -54,11 +54,12 @@ class PathExtractionConfig {
             searchPathByColumnName.put(columnName, searchPathExpression);
         }
 
-        final boolean caseSensitivity = Boolean.getBoolean(configuration.getOrDefault(CASE_SENSITIVITY_KEY, "false"));
+        final boolean caseSensitivity = Boolean.parseBoolean(configuration.getOrDefault(CASE_SENSITIVITY_KEY, "false"));
 
+        // Note: Serde property specifies case sensitivity, but path extractor APIs accept case insensitivity
         final PathExtractorBuilder<IonStruct> builder = PathExtractorBuilder.<IonStruct>standard()
-            .withMatchRelativePaths(false)
-            .withMatchCaseInsensitive(caseSensitivity);
+                .withMatchRelativePaths(false)
+                .withMatchCaseInsensitive(!caseSensitivity);
 
         for (final Entry<String, String> entry : searchPathByColumnName.entrySet()) {
             final String columnName = entry.getKey();


### PR DESCRIPTION
Currently the case_sensitive property does not work. getBoolean looks for a system variable with a specified name, so passing in "true" or "false" always fails. We are now calling parseBoolean, which will properly extract the property value.

Additionally, the Ion-Hive serde has a property called "case_sensitive", but the matching path_extractor property is "case_insensitive". This PR fixes the behavior - setting case_sensitive to true in the serde now causes the case_insensitive property of the extractor APIs to be set to false.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
