### PR TITLE
Adds case insensitive decorators.

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
@@ -22,6 +22,7 @@ import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonWriter;
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator;
 import com.amazon.ionhiveserde.configuration.IonEncoding;
 import com.amazon.ionhiveserde.configuration.SerDeProperties;
 import com.amazon.ionhiveserde.objectinspectors.factories.IonObjectInspectorFactory;
@@ -135,7 +136,10 @@ public class IonHiveSerDe extends AbstractSerDe {
 
         final IonSystem domFactory = ionFactory.getDomFactory();
         try (final IonReader reader = ionFactory.newReader(bytes, 0, length)) {
-            final IonStruct struct = domFactory.newEmptyStruct();
+            IonStruct struct = domFactory.newEmptyStruct();
+            if (!serDeProperties.pathExtractorCaseSensitivity()) {
+                struct = new IonStructCaseInsensitiveDecorator(struct);
+            }
             final PathExtractor<IonStruct> pathExtractor = serDeProperties.pathExtractor();
 
             pathExtractor.match(reader, struct);

--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonCaseInsensitiveDecorator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.caseinsensitivedecorator;
+
+import com.amazon.ion.IonSequence;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonValue;
+
+public class IonCaseInsensitiveDecorator {
+    /**
+     * Wraps an IonValue in an IonContainerCaseInsensitiveDecorator if it's an ion container.
+
+     * @return a case insensitive decorator wrapped Ion Value.
+     */
+    public static IonValue wrapValue(final IonValue v) {
+        if (v == null || v.isNullValue()) {
+            return null;
+        }
+
+        switch (v.getType()) {
+            case LIST:
+                // fallthrough
+            case SEXP:
+                return new IonSequenceCaseInsensitiveDecorator((IonSequence) v);
+            case STRUCT:
+                return new IonStructCaseInsensitiveDecorator((IonStruct) v);
+            default:
+                return v;
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonContainerCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonContainerCaseInsensitiveDecorator.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.caseinsensitivedecorator;
+
+import com.amazon.ion.IonContainer;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.NullValueException;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.UnknownSymbolException;
+import com.amazon.ion.ValueVisitor;
+import com.amazon.ion.system.IonTextWriterBuilder;
+
+import java.util.Iterator;
+
+import org.jetbrains.annotations.NotNull;
+
+class IonContainerCaseInsensitiveDecorator implements IonContainer {
+    IonContainer ionContainer;
+
+    public IonContainerCaseInsensitiveDecorator(final IonContainer c) {
+        this.ionContainer = c;
+    }
+
+    @Override
+    public int size() {
+        return ionContainer.size();
+    }
+
+    @NotNull
+    @Override
+    public Iterator<IonValue> iterator() {
+        return new IteratorCaseInsensitiveDecorator(ionContainer.iterator());
+    }
+
+    @Override
+    public boolean remove(final IonValue element) {
+        return ionContainer.remove(element);
+    }
+
+    @Override
+    public boolean isEmpty() throws NullValueException {
+        return ionContainer.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+        ionContainer.clear();
+    }
+
+    @Override
+    public void makeNull() {
+        ionContainer.makeNull();
+    }
+
+    @Override
+    public IonContainer clone() throws UnknownSymbolException {
+        return new IonContainerCaseInsensitiveDecorator(ionContainer.clone());
+    }
+
+    @Override
+    public IonType getType() {
+        return ionContainer.getType();
+    }
+
+    @Override
+    public boolean isNullValue() {
+        return ionContainer.isNullValue();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return ionContainer.isReadOnly();
+    }
+
+    @Override
+    public SymbolTable getSymbolTable() {
+        return ionContainer.getSymbolTable();
+    }
+
+    @Override
+    public String getFieldName() {
+        return ionContainer.getFieldName();
+    }
+
+    @Override
+    public SymbolToken getFieldNameSymbol() {
+        return ionContainer.getFieldNameSymbol();
+    }
+
+    @Override
+    @Deprecated
+    public int getFieldId() {
+        return ionContainer.getFieldId();
+    }
+
+    @Override
+    public IonContainer getContainer() {
+        return new IonContainerCaseInsensitiveDecorator(ionContainer.getContainer());
+    }
+
+    @Override
+    public boolean removeFromContainer() {
+        return ionContainer.removeFromContainer();
+    }
+
+    @Override
+    public IonValue topLevelValue() {
+        return IonCaseInsensitiveDecorator.wrapValue(ionContainer.topLevelValue());
+    }
+
+    @Override
+    public String[] getTypeAnnotations() {
+        return ionContainer.getTypeAnnotations();
+    }
+
+    @Override
+    public SymbolToken[] getTypeAnnotationSymbols() {
+        return ionContainer.getTypeAnnotationSymbols();
+    }
+
+    @Override
+    public boolean hasTypeAnnotation(final String annotation) {
+        return ionContainer.hasTypeAnnotation(annotation);
+    }
+
+    @Override
+    public void setTypeAnnotations(final String... annotations) {
+        ionContainer.setTypeAnnotations(annotations);
+    }
+
+    @Override
+    public void setTypeAnnotationSymbols(final SymbolToken... annotations) {
+        ionContainer.setTypeAnnotationSymbols(annotations);
+    }
+
+    @Override
+    public void clearTypeAnnotations() {
+        ionContainer.clearTypeAnnotations();
+    }
+
+    @Override
+    public void addTypeAnnotation(final String annotation) {
+        ionContainer.addTypeAnnotation(annotation);
+    }
+
+    @Override
+    public void removeTypeAnnotation(final String annotation) {
+        ionContainer.removeTypeAnnotation(annotation);
+    }
+
+    @Override
+    public void writeTo(final IonWriter writer) {
+        ionContainer.writeTo(writer);
+    }
+
+    @Override
+    public void accept(final ValueVisitor visitor) throws Exception {
+        ionContainer.accept(visitor);
+    }
+
+    @Override
+    public void makeReadOnly() {
+        ionContainer.makeReadOnly();
+    }
+
+    @Override
+    public IonSystem getSystem() {
+        return ionContainer.getSystem();
+    }
+
+    @Override
+    public String toPrettyString() {
+        return ionContainer.toPrettyString();
+    }
+
+    @Override
+    public String toString(final IonTextWriterBuilder writerBuilder) {
+        return ionContainer.toString();
+    }
+
+    public class IteratorCaseInsensitiveDecorator implements Iterator<IonValue> {
+        Iterator<IonValue> iterator;
+
+        public IteratorCaseInsensitiveDecorator(final Iterator<IonValue> l) {
+            this.iterator = l;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public IonValue next() {
+            return IonCaseInsensitiveDecorator.wrapValue(iterator.next());
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonSequenceCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonSequenceCaseInsensitiveDecorator.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.caseinsensitivedecorator;
+
+import com.amazon.ion.ContainedValueException;
+import com.amazon.ion.IonSequence;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.NullValueException;
+import com.amazon.ion.UnknownSymbolException;
+import com.amazon.ion.ValueFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+import org.jetbrains.annotations.NotNull;
+
+
+
+
+public class IonSequenceCaseInsensitiveDecorator extends IonContainerCaseInsensitiveDecorator implements IonSequence {
+    private final IonSequence ionSequence;
+
+    public IonSequenceCaseInsensitiveDecorator(final IonSequence s) {
+        super(s);
+        this.ionSequence = s;
+    }
+
+    @Override
+    public IonValue get(final int index) throws NullValueException, IndexOutOfBoundsException {
+        IonValue v = ionSequence.get(index);
+        return IonCaseInsensitiveDecorator.wrapValue(v);
+    }
+
+    @Override
+    public boolean add(final IonValue child) throws ContainedValueException, NullPointerException {
+        return ionSequence.add(child);
+    }
+
+    @Override
+    public ValueFactory add() {
+        return ionSequence.add();
+    }
+
+    @Override
+    public void add(final int index, final IonValue child) throws ContainedValueException, NullPointerException {
+        ionSequence.add();
+    }
+
+    @Override
+    public ValueFactory add(final int index) {
+        return ionSequence.add(index);
+    }
+
+    @Override
+    public IonValue set(final int index, final IonValue element) {
+        return IonCaseInsensitiveDecorator.wrapValue(ionSequence.set(index, element));
+    }
+
+    @Override
+    public IonValue remove(final int index) {
+        return IonCaseInsensitiveDecorator.wrapValue(ionSequence.remove(index));
+    }
+
+    @Override
+    public boolean remove(final Object o) {
+        return ionSequence.remove(o);
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> c) {
+        return ionSequence.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> c) {
+        return ionSequence.retainAll(c);
+    }
+
+    @Override
+    public boolean contains(final Object o) {
+        return ionSequence.contains(o);
+    }
+
+    @Override
+    public boolean containsAll(final Collection<?> c) {
+        return ionSequence.containsAll(c);
+    }
+
+    @Override
+    public int indexOf(final Object o) {
+        return ionSequence.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(final Object o) {
+        return ionSequence.lastIndexOf(o);
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends IonValue> c) {
+        return ionSequence.addAll(c);
+    }
+
+    @Override
+    public boolean addAll(final int index, final Collection<? extends IonValue> c) {
+        return ionSequence.addAll(index, c);
+    }
+
+    @NotNull
+    @Override
+    public ListIterator<IonValue> listIterator() {
+        return new ListIteratorCaseInsensitiveDecorator(ionSequence.listIterator());
+    }
+
+    @NotNull
+    @Override
+    public ListIterator<IonValue> listIterator(final int index) {
+        return new ListIteratorCaseInsensitiveDecorator(ionSequence.listIterator(index));
+    }
+
+    @NotNull
+    @Override
+    public List<IonValue> subList(final int fromIndex, final int toIndex) {
+        List<IonValue> l = new ArrayList<>();
+        List<IonValue> sublist = ionSequence.subList(fromIndex, toIndex);
+
+        for (IonValue ionValue : sublist) {
+            l.add(IonCaseInsensitiveDecorator.wrapValue(ionValue));
+        }
+        return l;
+    }
+
+    @NotNull
+    @Override
+    public IonValue[] toArray() {
+        IonValue[] rawArray = ionSequence.toArray();
+        int size = ionSequence.size();
+        for (int i = 0; i < size; i++) {
+            rawArray[i] = IonCaseInsensitiveDecorator.wrapValue(rawArray[i]);
+        }
+        return rawArray;
+    }
+
+    @NotNull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] a) {
+        T[] rawArray = ionSequence.toArray(a);
+        int size = rawArray.length;
+        for (int i = 0; i < size; i++) {
+            rawArray[i] = (T) IonCaseInsensitiveDecorator.wrapValue((IonValue) rawArray[i]);
+        }
+        return rawArray;
+    }
+
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends IonValue> T[] extract(final Class<T> type) {
+        T[] rawArray = ionSequence.extract(type);
+        int size = rawArray.length;
+        for (int i = 0; i < size; i++) {
+            rawArray[i] = (T) IonCaseInsensitiveDecorator.wrapValue((IonValue) rawArray[i]);
+        }
+        return rawArray;
+    }
+
+    public IonSequence clone() throws UnknownSymbolException {
+        return new IonSequenceCaseInsensitiveDecorator(ionSequence.clone());
+    }
+
+    public static class ListIteratorCaseInsensitiveDecorator implements ListIterator<IonValue> {
+        ListIterator<IonValue> listIterator;
+
+        public ListIteratorCaseInsensitiveDecorator(final ListIterator<IonValue> l) {
+            this.listIterator = l;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return listIterator.hasNext();
+        }
+
+        @Override
+        public IonValue next() {
+            return IonCaseInsensitiveDecorator.wrapValue(listIterator.next());
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return listIterator.hasPrevious();
+        }
+
+        @Override
+        public IonValue previous() {
+            return IonCaseInsensitiveDecorator.wrapValue(listIterator.previous());
+        }
+
+        @Override
+        public int nextIndex() {
+            return listIterator.nextIndex();
+        }
+
+        @Override
+        public int previousIndex() {
+            return listIterator.previousIndex();
+        }
+
+        @Override
+        public void remove() {
+            listIterator.remove();
+        }
+
+        @Override
+        public void set(final IonValue ionValue) {
+            listIterator.set(ionValue);
+        }
+
+        @Override
+        public void add(final IonValue ionValue) {
+            listIterator.add(ionValue);
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonStructCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonStructCaseInsensitiveDecorator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.caseinsensitivedecorator;
+
+import com.amazon.ion.ContainedValueException;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.UnknownSymbolException;
+import com.amazon.ion.ValueFactory;
+
+import java.util.Map;
+
+
+public class IonStructCaseInsensitiveDecorator extends IonContainerCaseInsensitiveDecorator implements IonStruct {
+    private final IonStruct ionStruct;
+
+    public IonStructCaseInsensitiveDecorator(final IonStruct s) {
+        super(s);
+        this.ionStruct = s;
+    }
+
+    @Override
+    public boolean containsKey(final Object fieldName) {
+        return ionStruct.containsKey(fieldName) || hasCaseInsensitiveFieldMatch(fieldName);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return ionStruct.containsValue(value);
+    }
+
+    @Override
+    public IonValue get(final String fieldName) {
+        IonValue v = ionStruct.get(fieldName);
+
+        if (v == null) {
+            String match = findCaseInsensitiveFieldMatch(fieldName);
+            if (match != null) {
+                return IonCaseInsensitiveDecorator.wrapValue(ionStruct.get(match));
+            }
+        }
+
+        return IonCaseInsensitiveDecorator.wrapValue(v);
+    }
+
+    @Override
+    public void put(final String fieldName, final IonValue child) throws ContainedValueException {
+        ionStruct.put(fieldName, child);
+    }
+
+    @Override
+    public ValueFactory put(final String fieldName) {
+        return ionStruct.put(fieldName);
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends IonValue> m) {
+        ionStruct.putAll(m);
+    }
+
+    @Override
+    public void add(final String fieldName, final IonValue child) throws ContainedValueException {
+        ionStruct.add(fieldName, child);
+    }
+
+    @Override
+    public void add(final SymbolToken fieldName, final IonValue child) throws ContainedValueException {
+        ionStruct.add(fieldName, child);
+    }
+
+    @Override
+    public ValueFactory add(final String fieldName) {
+        return ionStruct.add(fieldName);
+    }
+
+    @Override
+    public IonValue remove(final String fieldName) {
+        return IonCaseInsensitiveDecorator.wrapValue(ionStruct.remove(fieldName));
+    }
+
+    @Override
+    public boolean removeAll(final String... fieldNames) {
+        return ionStruct.removeAll(fieldNames);
+    }
+
+    @Override
+    public boolean retainAll(final String... fieldNames) {
+        return ionStruct.retainAll(fieldNames);
+    }
+
+    @Override
+    public IonStruct cloneAndRemove(final String... fieldNames) throws UnknownSymbolException {
+        return new IonStructCaseInsensitiveDecorator(ionStruct.cloneAndRemove(fieldNames));
+    }
+
+    @Override
+    public IonStruct cloneAndRetain(final String... fieldNames) throws UnknownSymbolException {
+        return new IonStructCaseInsensitiveDecorator(ionStruct.cloneAndRetain(fieldNames));
+    }
+
+    public IonStruct clone() throws UnknownSymbolException {
+        return new IonStructCaseInsensitiveDecorator(ionStruct.clone());
+    }
+
+    private String findCaseInsensitiveFieldMatch(final String fieldName) {
+        for (IonValue v : ionStruct) {
+            if (fieldName.equalsIgnoreCase(v.getFieldName())) {
+                return v.getFieldName();
+            }
+        }
+        return null;
+    }
+
+    private boolean hasCaseInsensitiveFieldMatch(final Object fieldName) {
+        if (fieldName instanceof String) {
+            return findCaseInsensitiveFieldMatch((String)fieldName) != null;
+        } else {
+            return false;
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
@@ -37,6 +37,7 @@ class PathExtractionConfig {
     private static final String CASE_SENSITIVITY_KEY = "ion.path_extractor.case_sensitive";
 
     private final PathExtractor<IonStruct> pathExtractor;
+    private final Boolean caseSensitivity;
 
     /**
      * Constructor.
@@ -55,7 +56,7 @@ class PathExtractionConfig {
         }
 
         final boolean caseSensitivity = Boolean.parseBoolean(configuration.getOrDefault(CASE_SENSITIVITY_KEY, "false"));
-
+        this.caseSensitivity = caseSensitivity;
         // Note: Serde property specifies case sensitivity, but path extractor APIs accept case insensitivity
         final PathExtractorBuilder<IonStruct> builder = PathExtractorBuilder.<IonStruct>standard()
                 .withMatchRelativePaths(false)
@@ -90,5 +91,14 @@ class PathExtractionConfig {
      */
     PathExtractor<IonStruct> pathExtractor() {
         return pathExtractor;
+    }
+
+    /**
+     * Returns a boolean that indicates if the pathExtractor is configured case sensitive.
+
+     * @return true if the pathExtractor is configured case sensitive, false otherwise.
+     */
+    public Boolean getCaseSensitivity() {
+        return caseSensitivity;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/SerDeProperties.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/SerDeProperties.java
@@ -115,5 +115,12 @@ public class SerDeProperties extends BaseProperties {
     public PathExtractor<IonStruct> pathExtractor() {
         return pathExtractionConfig.pathExtractor();
     }
+
+    /**
+     * @return Boolean that indicates if the path extractor is configured case sensitive
+     */
+    public Boolean pathExtractorCaseSensitivity() {
+        return pathExtractionConfig.getCaseSensitivity();
+    }
 }
 

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.configuration
+
+import com.amazon.ion.*
+import com.amazon.ionhiveserde.ION
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensitiveDecorator
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaseInsensitiveDecoratorTest {
+    private fun datagram_for(s: String): IonDatagram {
+        return ION.loader.load(s)
+    }
+
+    private fun struct_for(s: String): IonStruct {
+        val v = datagram_for(s).iterator().next()
+        if (v !is IonStruct) throw IllegalArgumentException("Required an IonStruct, found ${v.javaClass.simpleName}")
+
+        return IonStructCaseInsensitiveDecorator(v)
+    }
+
+    private fun sequence_for(s: String): IonSequence {
+        val v = datagram_for(s).iterator().next()
+        if (v !is IonSequence) throw IllegalArgumentException("Required an IonSequence, found ${v.javaClass.simpleName}")
+
+        return IonSequenceCaseInsensitiveDecorator(v)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorContainsKey() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        assertEquals(struct.containsKey("foo"), true)
+        assertEquals(struct.containsKey("bar"), false)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetExist() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        assertEquals(struct.containsKey("Foo"), true)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetNotExist() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        assertEquals(struct.containsKey("bar"), false)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetIgnoreCase() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        assertEquals(struct.containsKey("foO"), true)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetRepeatedField() {
+        val struct = struct_for(" { Foo: 'bar', foo: 'Bar' }")
+        assertEquals(struct.containsKey("FOO"), true)
+        assertEquals(struct.get("Foo"), ION.newSymbol("bar"))
+        assertEquals(struct.get("foo"), ION.newSymbol("Bar"))
+        assert(
+            struct.get("FOO") == ION.newSymbol("Bar") ||
+            struct.get("FOO") == ION.newSymbol("bar")
+        )
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetStruct() {
+        val struct = struct_for(" { Foo: {} }")
+        assertTrue(struct.get("Foo") is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorGetSequence() {
+        val struct = struct_for(" { Foo: [] }")
+        assertTrue(struct.get("Foo") is IonSequenceCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorRemove() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        val s = struct.remove("Foo")
+
+        assertEquals(0, struct.size())
+        assertEquals(s, ION.newSymbol("bar"))
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorRemoveStruct() {
+        val struct = struct_for(" { Foo: {} }")
+        val s = struct.remove("Foo")
+        assertTrue(s is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorRemoveSequence() {
+        val struct = struct_for(" { Foo: [] }")
+        val s = struct.remove("Foo")
+        assertTrue(s is IonSequenceCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorCloneAndRemove() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        val s = struct.cloneAndRemove("Foo")
+
+        assertEquals(s.size(), 0)
+        assertTrue(s is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorCloneAndRetain() {
+        val struct = struct_for(" { Foo: 'bar' }")
+        val s = struct.cloneAndRetain("Foo")
+
+        assertEquals(s.size(), 1)
+        assertEquals(s.containsKey("foo"), true)
+        assertTrue(s is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorGet() {
+        val sequence = sequence_for("[1, '2']")
+        assertEquals(sequence[1], ION.newSymbol("2"))
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorGetStruct() {
+        val sequence = sequence_for("[{}]")
+        assertTrue(sequence[0] is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorGetSequence() {
+        val sequence = sequence_for("[[]]")
+        assertTrue(sequence[0] is IonSequenceCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorSet() {
+        val sequence = sequence_for("[1]")
+        val l = sequence.set(0, ION.newInt(2))
+
+        assertEquals(sequence[0], ION.newInt(2))
+        assertEquals(l, ION.newInt(1))
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorSetStruct() {
+        val sequence = sequence_for("[{}]")
+        val l = sequence.set(0, ION.newInt(2))
+        assertTrue(l is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorSetSequence() {
+        val sequence = sequence_for("[[]]")
+        val l = sequence.set(0, ION.newInt(2))
+        assertTrue(l is IonSequenceCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorRemove() {
+        val sequence = sequence_for("[1]")
+        val l = sequence.removeAt(0)
+
+        assertEquals(sequence.size, 0)
+        assertEquals(l, ION.newInt(1))
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorRemoveStruct() {
+        val sequence = sequence_for("[{}]")
+        val l = sequence.removeAt(0)
+
+        assertTrue(l is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorRemoveSequence() {
+        val sequence = sequence_for("[[]]")
+        val l = sequence.removeAt(0)
+
+        assertTrue(l is IonSequenceCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorListIterator() {
+        val sequence = sequence_for("[1, [], {}]")
+        val iter = sequence.listIterator()
+        assertEquals(iter.next(), ION.newInt(1))
+        assertTrue(iter.next() is IonSequenceCaseInsensitiveDecorator)
+        assertTrue(iter.next() is IonStructCaseInsensitiveDecorator)
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorSublist() {
+        val sequence = sequence_for("[1, [], {}]")
+        val sublist = sequence.subList(0, 3)
+        // sublist: [1, [], {}]
+        assertEquals(sublist[0], ION.newInt(1))
+        assertTrue(sublist[1] is IonSequenceCaseInsensitiveDecorator)
+        assertTrue(sublist[2] is IonStructCaseInsensitiveDecorator)
+    }
+}


### PR DESCRIPTION
### Description 

Fixing the issue #51, Ion is case sensitive and path extractor's case insensitive flag is targeting to the field names only (E.g. It's still case insensitive within a nested struct). One of the most scalable ways to solve the issue is implementing a case insensitive decorator which wraps an Ion Container. For read methods such as `containsKey`, `get`, `iterator`, the decorator should return a case insensitive decorator wrapped Ion Container as well without accessing the underlying Ion struct directly to make sure all fields within a nested container are also case insensitive. 


### Test:
Passed unit tests/integration tests. In addition, it worked correctly in the EMR environment.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
