### PR TITLE
Updates a reference to Ion Docs to use 'https' instead of 'http'

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java
@@ -52,7 +52,7 @@ import org.apache.hadoop.io.Writable;
 
 /**
  * <p>
- * Hive SerDe for the <a href="http://amzn.github.io/ion-docs/docs.html">Amazon Ion</a> data format.
+ * Hive SerDe for the <a href="https://amzn.github.io/ion-docs/docs.html">Amazon Ion</a> data format.
  * </p>
  * <p>
  * For more information on Hive SerDes see <a href="https://cwiki.apache.org/confluence/display/Hive/SerDe">wiki</a>.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Changes a `href` that was using `http` to use `https` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
