### PR TITLE
Add FieldName to Hive primitive object inspectors

### DIFF
--- a/serde/build.gradle
+++ b/serde/build.gradle
@@ -18,6 +18,7 @@ group = "com.amazon.ion"
 
 apply plugin: 'java-library'
 apply plugin: "maven-publish"
+apply plugin: "maven"
 apply plugin: "signing"
 
 jar.baseName = 'ion-hive-serde'

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
@@ -32,7 +32,7 @@ class EncodingConfig {
      * @param configuration raw configuration.
      */
     EncodingConfig(final RawConfiguration configuration) {
-        encoding = IonEncoding.valueOf(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING));
+        encoding = IonEncoding.valueOf(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING).toUpperCase());
     }
 
     /**

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/EncodingConfig.java
@@ -32,7 +32,7 @@ class EncodingConfig {
      * @param configuration raw configuration.
      */
     EncodingConfig(final RawConfiguration configuration) {
-        encoding = IonEncoding.valueOf(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING).toUpperCase());
+        encoding = IonEncoding.fromConfigValue(configuration.getOrDefault(ENCODING_KEY, DEFAULT_ENCODING));
     }
 
     /**

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/IonEncoding.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/IonEncoding.java
@@ -27,5 +27,14 @@ public enum IonEncoding {
     /**
      * Ion text.
      */
-    TEXT
+    TEXT;
+
+    /**
+     * Case insensitive function to retrieve the encoding from a user specified value.
+     * @param encodingValue - String with the encoding value (usually passed in ion.encoding)
+     * @return Enum value corresponding to the passed in string
+     */
+    public static IonEncoding fromConfigValue(final String encodingValue) {
+        return IonEncoding.valueOf(encodingValue.toUpperCase());
+    }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
@@ -100,17 +100,15 @@ public class IonObjectInspectorFactory {
 
     // Map Key Object Inspectors
     private static final IonFieldNameToBooleanObjectInspector FIELD_NAME_TO_BOOLEAN_OBJECT_INSPECTOR =
-            new IonFieldNameToBooleanObjectInspector(true);
+            new IonFieldNameToBooleanObjectInspector();
     private static final IonFieldNameToBigIntObjectInspector FIELD_NAME_TO_BIGINT_OBJECT_INSPECTOR =
-            new IonFieldNameToBigIntObjectInspector(false);
-    private static final IonFieldNameToBigIntObjectInspector FIELD_NAME_TO_BIGINT_FAIL_OBJECT_INSPECTOR =
-            new IonFieldNameToBigIntObjectInspector(true);
-    private static final IonFieldNameToDecimalObjectInspector FIELD_NAME_TO_DECIMAL_OBJECT_INSPECTOR =
-            new IonFieldNameToDecimalObjectInspector(false);
+            new IonFieldNameToBigIntObjectInspector();
     private static final IonFieldNameToDateObjectInspector FIELD_NAME_TO_DATE_OBJECT_INSPECTOR =
-            new IonFieldNameToDateObjectInspector(false);
+            new IonFieldNameToDateObjectInspector();
+    private static final IonFieldNameToDecimalObjectInspector FIELD_NAME_TO_DECIMAL_OBJECT_INSPECTOR =
+            new IonFieldNameToDecimalObjectInspector();
     private static final IonFieldNameToDoubleObjectInspector FIELD_NAME_TO_DOUBLE_OBJECT_INSPECTOR =
-            new IonFieldNameToDoubleObjectInspector(false);
+            new IonFieldNameToDoubleObjectInspector();
     private static final IonFieldNameToFloatObjectInspector FIELD_NAME_TO_FLOAT_FAIL_OBJECT_INSPECTOR =
             new IonFieldNameToFloatObjectInspector(true);
     private static final IonFieldNameToFloatObjectInspector FIELD_NAME_TO_FLOAT_OBJECT_INSPECTOR =
@@ -123,14 +121,14 @@ public class IonObjectInspectorFactory {
             new IonFieldNameToSmallIntObjectInspector(true);
     private static final IonFieldNameToSmallIntObjectInspector FIELD_NAME_TO_SMALLINT_OBJECT_INSPECTOR =
             new IonFieldNameToSmallIntObjectInspector(false);
+    private static final IonFieldNameToStringObjectInspector FIELD_NAME_TO_STRING_OBJECT_INSPECTOR =
+            new IonFieldNameToStringObjectInspector();
     private static final IonFieldNameToTimestampObjectInspector FIELD_NAME_TO_TIMESTAMP_OBJECT_INSPECTOR =
-            new IonFieldNameToTimestampObjectInspector(false);
+            new IonFieldNameToTimestampObjectInspector();
     private static final IonFieldNameToTinyIntObjectInspector FIELD_NAME_TO_TINYINT_FAIL_OBJECT_INSPECTOR =
             new IonFieldNameToTinyIntObjectInspector(true);
     private static final IonFieldNameToTinyIntObjectInspector FIELD_NAME_TO_TINYINT_OBJECT_INSPECTOR =
             new IonFieldNameToTinyIntObjectInspector(false);
-    private static final IonFieldNameToStringObjectInspector FIELD_NAME_TO_STRING_OBJECT_INSPECTOR =
-            new IonFieldNameToStringObjectInspector(true);
 
     /**
      * Creates an object inspector for the table correctly configured.
@@ -346,9 +344,7 @@ public class IonObjectInspectorFactory {
                                 : FIELD_NAME_TO_INT_OBJECT_INSPECTOR;
                         break;
                     case LONG:
-                        objectInspector = failOnOverflow
-                                ? FIELD_NAME_TO_BIGINT_FAIL_OBJECT_INSPECTOR
-                                : FIELD_NAME_TO_BIGINT_OBJECT_INSPECTOR;
+                        objectInspector = FIELD_NAME_TO_BIGINT_OBJECT_INSPECTOR;
                         break;
                     case SHORT:
                         objectInspector = failOnOverflow

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractFieldNameObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractFieldNameObjectInspector.java
@@ -55,12 +55,18 @@ abstract class AbstractFieldNameObjectInspector<O> extends
      * @param fieldName Value to read as a Java primitive.
      * @return Java primitive representation.
      */
-    final O getPrimitiveJavaObjectFromFieldName(final String fieldName) {
+    final O getPrimitiveJavaObjectFromFieldName(final Object fieldName) {
+        final String fieldNameAsString;
+        if (fieldName instanceof String) {
+            fieldNameAsString = (String) fieldName;
+        } else {
+            fieldNameAsString = fieldName.toString();
+        }
         if (failOnOverflow) {
-            validateSize(fieldName);
+            validateSize(fieldNameAsString);
         }
 
-        return getValidatedPrimitiveJavaObject(fieldName);
+        return getValidatedPrimitiveJavaObject(fieldNameAsString);
     }
 
     /**
@@ -84,5 +90,15 @@ abstract class AbstractFieldNameObjectInspector<O> extends
                     String.format("Type %s is marked as fail on overflow, but has not implemented validation",
                             this.getClass().getSimpleName()));
         }
+    }
+
+    /**
+     * Returns a java primitive object from a field name
+     * @param o - Object o that contains a string version of the field name
+     * @return Java primitive object
+     */
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractOverflowableFieldNameObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/AbstractOverflowableFieldNameObjectInspector.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import com.amazon.ionhiveserde.objectinspectors.AbstractIonPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+
+/**
+ * Base class for primitive object inspectors that need to handle overflow detection.
+ *
+ * @param <T> Ion type.
+ * @param <O> Primitive type.
+ */
+abstract class AbstractOverflowableFieldNameObjectInspector<T, O> extends
+        AbstractIonPrimitiveJavaObjectInspector {
+
+    private final boolean failOnOverflow;
+
+    /**
+     * Constructor.
+     *
+     * @param typeInfo type info for this object inspector.
+     * @param failOnOverflow if should fail when detecting an overflow.
+     */
+    AbstractOverflowableFieldNameObjectInspector(final PrimitiveTypeInfo typeInfo,
+                                                 final boolean failOnOverflow) {
+        super(typeInfo);
+        this.failOnOverflow = failOnOverflow;
+    }
+
+    /**
+     * Gets the primitive Java representation of an Ion value detecting and handling overflows.
+     *
+     * @param ionValue Value to read as a Java primitive.
+     * @return Java primitive representation.
+     */
+    final O getPrimitiveJavaObjectFromIonValue(final T ionValue) {
+        if (failOnOverflow) {
+            validateSize(ionValue);
+        }
+
+        return getValidatedPrimitiveJavaObject(ionValue);
+    }
+
+    /**
+     * Gets the primitive Java representation of an Ion value that has passed overflow validation.
+     *
+     * @param ionValue Value to read as a Java primitive.
+     * @return Java primitive representation.
+     */
+    protected abstract O getValidatedPrimitiveJavaObject(final T ionValue);
+
+    /**
+     * Validates if an ion value will overflow when converted to java primitive.
+     *
+     * @param ionValue Ion value to be validated.
+     * @throws IllegalArgumentException when detecting an overflow.
+     */
+    protected abstract void validateSize(final T ionValue);
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.LongWritable;
@@ -45,8 +46,8 @@ public class IonFieldNameToBigIntObjectInspector
     @Override
     protected Long getValidatedPrimitiveJavaObject(final String fieldName) {
         try {
-            return Long.parseLong(fieldName);
-        } catch (NumberFormatException e) {
+            return IonPrimitiveReader.longValue(fieldName);
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
         }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
@@ -34,13 +34,8 @@ public class IonFieldNameToBigIntObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new LongWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new LongWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.LongWritable;
+
+public class IonFieldNameToBigIntObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Long>
+        implements LongObjectInspector {
+
+    public static final long MIN_VALUE = Long.MIN_VALUE;
+    public static final long MAX_VALUE = Long.MAX_VALUE;
+
+    public IonFieldNameToBigIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.longTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Long getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Long.parseLong(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            long value = Long.parseLong(fieldName);
+
+            if (!validRange(value)) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java long
+        return MIN_VALUE <= value && value <= MAX_VALUE;
+    }
+
+    @Override
+    public long get(final Object o) {
+        return (long) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new LongWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBigIntObjectInspector.java
@@ -20,39 +20,11 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.LongWritable;
 
 public class IonFieldNameToBigIntObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Long>
+        extends AbstractFieldNameObjectInspector<Long>
         implements LongObjectInspector {
 
-    public static final long MIN_VALUE = Long.MIN_VALUE;
-    public static final long MAX_VALUE = Long.MAX_VALUE;
-
-    public IonFieldNameToBigIntObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.longTypeInfo, failOnOverflow);
-    }
-
-    @Override
-    protected Long getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Long.parseLong(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        try {
-            long value = Long.parseLong(fieldName);
-
-            if (!validRange(value)) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
-        }
-    }
-
-    private boolean validRange(final long value) {
-        // runs after checking that fits in a Java long
-        return MIN_VALUE <= value && value <= MAX_VALUE;
+    public IonFieldNameToBigIntObjectInspector() {
+        super(TypeInfoFactory.longTypeInfo);
     }
 
     @Override
@@ -62,11 +34,21 @@ public class IonFieldNameToBigIntObjectInspector
 
     @Override
     public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new LongWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new LongWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
+    protected Long getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return Long.parseLong(fieldName);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.BooleanWritable;
+
+public class IonFieldNameToBooleanObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Boolean>
+        implements BooleanObjectInspector {
+
+    public IonFieldNameToBooleanObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.booleanTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Boolean getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Boolean.parseBoolean(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            Boolean booleanValue = Boolean.parseBoolean(fieldName);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    public boolean get(final Object o) {
+        return (boolean) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new BooleanWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
@@ -34,13 +34,8 @@ public class IonFieldNameToBooleanObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new BooleanWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new BooleanWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
@@ -20,26 +20,11 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BooleanWritable;
 
 public class IonFieldNameToBooleanObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Boolean>
+        extends AbstractFieldNameObjectInspector<Boolean>
         implements BooleanObjectInspector {
 
-    public IonFieldNameToBooleanObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.booleanTypeInfo, failOnOverflow);
-    }
-
-    @Override
-    protected Boolean getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Boolean.parseBoolean(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        try {
-            Boolean booleanValue = Boolean.parseBoolean(fieldName);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
-        }
+    public IonFieldNameToBooleanObjectInspector() {
+        super(TypeInfoFactory.booleanTypeInfo);
     }
 
     @Override
@@ -49,11 +34,16 @@ public class IonFieldNameToBooleanObjectInspector
 
     @Override
     public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new BooleanWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new BooleanWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
+    protected Boolean getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Boolean.parseBoolean(fieldName);
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToBooleanObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BooleanWritable;
@@ -44,6 +45,11 @@ public class IonFieldNameToBooleanObjectInspector
 
     @Override
     protected Boolean getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Boolean.parseBoolean(fieldName);
+        try {
+            return IonPrimitiveReader.booleanValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
@@ -34,12 +34,12 @@ public class IonFieldNameToDateObjectInspector
 
     @Override
     public Date getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o);
     }
 
     @Override
     public DateWritable getPrimitiveWritableObject(final Object o) {
-        return new DateWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new DateWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
@@ -15,7 +15,11 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ion.Timestamp;
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import java.sql.Date;
+import java.time.LocalDate;
+
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -40,6 +44,12 @@ public class IonFieldNameToDateObjectInspector
 
     @Override
     protected Date getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Date.valueOf(fieldName);
+        try {
+            Timestamp ionTimestamp = IonPrimitiveReader.timestampValue(fieldName);
+            return Date.valueOf(LocalDate.of(ionTimestamp.getYear(), ionTimestamp.getMonth(), ionTimestamp.getDay()));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
@@ -21,30 +21,25 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspect
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IonFieldNameToDateObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Date>
+        extends AbstractFieldNameObjectInspector<Date>
         implements DateObjectInspector {
 
-    public IonFieldNameToDateObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.dateTypeInfo, failOnOverflow);
+    public IonFieldNameToDateObjectInspector() {
+        super(TypeInfoFactory.dateTypeInfo);
     }
 
     @Override
     public Date getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public DateWritable getPrimitiveWritableObject(final Object o) {
-        return new DateWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new DateWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
     }
 
     @Override
     protected Date getValidatedPrimitiveJavaObject(final String fieldName) {
         return Date.valueOf(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        // no-op
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDateObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import java.sql.Date;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToDateObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Date>
+        implements DateObjectInspector {
+
+    public IonFieldNameToDateObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.dateTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public Date getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public DateWritable getPrimitiveWritableObject(final Object o) {
+        return new DateWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+
+    @Override
+    protected Date getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Date.valueOf(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        // no-op
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
@@ -21,30 +21,25 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObject
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IonFieldNameToDecimalObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, HiveDecimal>
+        extends AbstractFieldNameObjectInspector<HiveDecimal>
         implements HiveDecimalObjectInspector {
 
-    public IonFieldNameToDecimalObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.decimalTypeInfo, failOnOverflow);
+    public IonFieldNameToDecimalObjectInspector() {
+        super(TypeInfoFactory.decimalTypeInfo);
     }
 
     @Override
     public HiveDecimal getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public HiveDecimalWritable getPrimitiveWritableObject(final Object o) {
-        return new HiveDecimalWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new HiveDecimalWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
     }
 
     @Override
     protected HiveDecimal getValidatedPrimitiveJavaObject(final String fieldName) {
         return HiveDecimal.create(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        // no-op
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToDecimalObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, HiveDecimal>
+        implements HiveDecimalObjectInspector {
+
+    public IonFieldNameToDecimalObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.decimalTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public HiveDecimal getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public HiveDecimalWritable getPrimitiveWritableObject(final Object o) {
+        return new HiveDecimalWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+
+    @Override
+    protected HiveDecimal getValidatedPrimitiveJavaObject(final String fieldName) {
+        return HiveDecimal.create(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        // no-op
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
@@ -40,6 +41,11 @@ public class IonFieldNameToDecimalObjectInspector
 
     @Override
     protected HiveDecimal getValidatedPrimitiveJavaObject(final String fieldName) {
-        return HiveDecimal.create(fieldName);
+        try {
+            return HiveDecimal.create(IonPrimitiveReader.decimalValue(fieldName));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDecimalObjectInspector.java
@@ -31,12 +31,12 @@ public class IonFieldNameToDecimalObjectInspector
 
     @Override
     public HiveDecimal getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o);
     }
 
     @Override
     public HiveDecimalWritable getPrimitiveWritableObject(final Object o) {
-        return new HiveDecimalWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new HiveDecimalWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
@@ -35,12 +35,12 @@ public class IonFieldNameToDoubleObjectInspector
 
     @Override
     public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o);
     }
 
     @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new DoubleWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new DoubleWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
@@ -20,26 +20,11 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.DoubleWritable;
 
 public class IonFieldNameToDoubleObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Double>
+        extends AbstractFieldNameObjectInspector<Double>
         implements DoubleObjectInspector {
 
-    public IonFieldNameToDoubleObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.doubleTypeInfo, failOnOverflow);
-    }
-
-    @Override
-    protected Double getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Double.parseDouble(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        try {
-            double doubleValue = Double.parseDouble(fieldName);
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
-        }
+    public IonFieldNameToDoubleObjectInspector() {
+        super(TypeInfoFactory.doubleTypeInfo);
     }
 
     @Override
@@ -49,11 +34,21 @@ public class IonFieldNameToDoubleObjectInspector
 
     @Override
     public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new DoubleWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new DoubleWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
+    protected Double getValidatedPrimitiveJavaObject(final String fieldName) {
+        try {
+            return Double.parseDouble(fieldName);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.DoubleWritable;
@@ -45,8 +46,8 @@ public class IonFieldNameToDoubleObjectInspector
     @Override
     protected Double getValidatedPrimitiveJavaObject(final String fieldName) {
         try {
-            return Double.parseDouble(fieldName);
-        } catch (NumberFormatException e) {
+            return IonPrimitiveReader.doubleValue(fieldName);
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
         }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToDoubleObjectInspector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.DoubleWritable;
+
+public class IonFieldNameToDoubleObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Double>
+        implements DoubleObjectInspector {
+
+    public IonFieldNameToDoubleObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.doubleTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Double getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Double.parseDouble(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            double doubleValue = Double.parseDouble(fieldName);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    public double get(final Object o) {
+        return (double) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new DoubleWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
@@ -34,13 +34,8 @@ public class IonFieldNameToFloatObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new FloatWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new FloatWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
@@ -20,32 +20,11 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.FloatWritable;
 
 public class IonFieldNameToFloatObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Float>
+        extends AbstractFieldNameObjectInspector<Float>
         implements FloatObjectInspector {
 
     public IonFieldNameToFloatObjectInspector(final boolean failOnOverflow) {
         super(TypeInfoFactory.floatTypeInfo, failOnOverflow);
-    }
-
-    @Override
-    protected Float getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Float.parseFloat(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        try {
-            double doubleValue = Double.parseDouble(fieldName);
-            double floatValue = Float.parseFloat(fieldName);
-
-            if (Double.compare(floatValue, doubleValue) != 0) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
-        }
     }
 
     @Override
@@ -55,11 +34,31 @@ public class IonFieldNameToFloatObjectInspector
 
     @Override
     public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new FloatWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new FloatWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
+    protected Float getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Double.valueOf(fieldName).floatValue();
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            Double doubleValue = Double.valueOf(fieldName);
+
+            if (Double.compare(doubleValue.floatValue(), doubleValue) != 0) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.FloatWritable;
+
+public class IonFieldNameToFloatObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Float>
+        implements FloatObjectInspector {
+
+    public IonFieldNameToFloatObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.floatTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Float getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Float.parseFloat(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            double doubleValue = Double.parseDouble(fieldName);
+            double floatValue = Float.parseFloat(fieldName);
+
+            if (Double.compare(floatValue, doubleValue) != 0) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    @Override
+    public float get(final Object o) {
+        return (float) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new FloatWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToFloatObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.FloatWritable;
@@ -44,21 +45,21 @@ public class IonFieldNameToFloatObjectInspector
 
     @Override
     protected Float getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Double.valueOf(fieldName).floatValue();
+        try {
+            return IonPrimitiveReader.floatValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 
     @Override
     protected void validateSize(final String fieldName) {
-        try {
-            Double doubleValue = Double.valueOf(fieldName);
+        Double doubleValue = IonPrimitiveReader.doubleValue(fieldName);
 
-            if (Double.compare(doubleValue.floatValue(), doubleValue) != 0) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
+        if (Double.compare(doubleValue.floatValue(), doubleValue) != 0) {
             throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+                    "insufficient precision for " + fieldName + " as " + this.typeInfo.getTypeName());
         }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.IntWritable;
+
+public class IonFieldNameToIntObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Integer>
+        implements IntObjectInspector {
+
+    public static final long MIN_VALUE = Integer.MIN_VALUE;
+    public static final long MAX_VALUE = Integer.MAX_VALUE;
+
+    public IonFieldNameToIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.intTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Integer getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Integer.parseInt(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            long value = Long.parseLong(fieldName);
+
+            if (!validRange(value)) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java int
+        return MIN_VALUE <= value && value <= MAX_VALUE;
+    }
+
+    @Override
+    public int get(final Object o) {
+        return (int) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new IntWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
@@ -20,7 +20,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.IntWritable;
 
 public class IonFieldNameToIntObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Integer>
+        extends AbstractFieldNameObjectInspector<Integer>
         implements IntObjectInspector {
 
     public static final long MIN_VALUE = Integer.MIN_VALUE;
@@ -31,8 +31,23 @@ public class IonFieldNameToIntObjectInspector
     }
 
     @Override
+    public int get(final Object o) {
+        return (int) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new IntWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
     protected Integer getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Integer.parseInt(fieldName);
+        return Long.valueOf(fieldName).intValue();
     }
 
     @Override
@@ -53,20 +68,5 @@ public class IonFieldNameToIntObjectInspector
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java int
         return MIN_VALUE <= value && value <= MAX_VALUE;
-    }
-
-    @Override
-    public int get(final Object o) {
-        return (int) getPrimitiveJavaObject(o);
-    }
-
-    @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
-    }
-
-    @Override
-    public Object getPrimitiveWritableObject(final Object o) {
-        return new IntWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.IntWritable;
@@ -47,21 +48,21 @@ public class IonFieldNameToIntObjectInspector
 
     @Override
     protected Integer getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Long.valueOf(fieldName).intValue();
+        try {
+            return IonPrimitiveReader.intValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 
     @Override
     protected void validateSize(final String fieldName) {
-        try {
-            long value = Long.parseLong(fieldName);
+        long value = IonPrimitiveReader.longValue(fieldName);
 
-            if (!validRange(value)) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
+        if (!validRange(value)) {
             throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
         }
     }
 

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToIntObjectInspector.java
@@ -24,9 +24,6 @@ public class IonFieldNameToIntObjectInspector
         extends AbstractFieldNameObjectInspector<Integer>
         implements IntObjectInspector {
 
-    public static final long MIN_VALUE = Integer.MIN_VALUE;
-    public static final long MAX_VALUE = Integer.MAX_VALUE;
-
     public IonFieldNameToIntObjectInspector(final boolean failOnOverflow) {
         super(TypeInfoFactory.intTypeInfo, failOnOverflow);
     }
@@ -37,13 +34,8 @@ public class IonFieldNameToIntObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new IntWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new IntWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override
@@ -68,6 +60,6 @@ public class IonFieldNameToIntObjectInspector
 
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java int
-        return MIN_VALUE <= value && value <= MAX_VALUE;
+        return Integer.MIN_VALUE <= value && value <= Integer.MAX_VALUE;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.ShortWritable;
+
+public class IonFieldNameToSmallIntObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Short>
+        implements ShortObjectInspector {
+    public static final long MIN_VALUE = Short.MIN_VALUE;
+    public static final long MAX_VALUE = Short.MAX_VALUE;
+
+    public IonFieldNameToSmallIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.shortTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Short getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Short.parseShort(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            long value = Long.parseLong(fieldName);
+
+            if (!validRange(value)) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java short
+        return MIN_VALUE <= value && value <= MAX_VALUE;
+    }
+
+    @Override
+    public short get(final Object o) {
+        return (short) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.io.ShortWritable;
 public class IonFieldNameToSmallIntObjectInspector
         extends AbstractFieldNameObjectInspector<Short>
         implements ShortObjectInspector {
-    public static final long MIN_VALUE = Short.MIN_VALUE;
-    public static final long MAX_VALUE = Short.MAX_VALUE;
 
     public IonFieldNameToSmallIntObjectInspector(final boolean failOnOverflow) {
         super(TypeInfoFactory.shortTypeInfo, failOnOverflow);
@@ -36,13 +34,8 @@ public class IonFieldNameToSmallIntObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override
@@ -67,6 +60,6 @@ public class IonFieldNameToSmallIntObjectInspector
 
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java short
-        return MIN_VALUE <= value && value <= MAX_VALUE;
+        return Short.MIN_VALUE <= value && value <= Short.MAX_VALUE;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.ShortWritable;
@@ -46,21 +47,21 @@ public class IonFieldNameToSmallIntObjectInspector
 
     @Override
     protected Short getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Long.valueOf(fieldName).shortValue();
+        try {
+            return IonPrimitiveReader.shortValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 
     @Override
     protected void validateSize(final String fieldName) {
-        try {
-            long value = Long.parseLong(fieldName);
+        long value = IonPrimitiveReader.longValue(fieldName);
 
-            if (!validRange(value)) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
+        if (!validRange(value)) {
             throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
         }
     }
 

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToSmallIntObjectInspector.java
@@ -20,7 +20,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.ShortWritable;
 
 public class IonFieldNameToSmallIntObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Short>
+        extends AbstractFieldNameObjectInspector<Short>
         implements ShortObjectInspector {
     public static final long MIN_VALUE = Short.MIN_VALUE;
     public static final long MAX_VALUE = Short.MAX_VALUE;
@@ -30,8 +30,23 @@ public class IonFieldNameToSmallIntObjectInspector
     }
 
     @Override
+    public short get(final Object o) {
+        return (short) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
     protected Short getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Short.parseShort(fieldName);
+        return Long.valueOf(fieldName).shortValue();
     }
 
     @Override
@@ -52,20 +67,5 @@ public class IonFieldNameToSmallIntObjectInspector
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java short
         return MIN_VALUE <= value && value <= MAX_VALUE;
-    }
-
-    @Override
-    public short get(final Object o) {
-        return (short) getPrimitiveJavaObject(o);
-    }
-
-    @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
-    }
-
-    @Override
-    public Object getPrimitiveWritableObject(final Object o) {
-        return new ShortWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
@@ -39,6 +40,11 @@ public class IonFieldNameToStringObjectInspector
 
     @Override
     protected String getValidatedPrimitiveJavaObject(final String fieldName) {
-        return fieldName;
+        try {
+            return IonPrimitiveReader.stringValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
@@ -30,12 +30,12 @@ public class IonFieldNameToStringObjectInspector
 
     @Override
     public Text getPrimitiveWritableObject(final Object o) {
-        return new Text(o.toString());
+        return new Text(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override
     public String getPrimitiveJavaObject(final Object o) {
-        return o.toString();
+        return getPrimitiveJavaObjectFromFieldName(o);
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+public class IonFieldNameToStringObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, String>
+        implements StringObjectInspector {
+
+    public IonFieldNameToStringObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.stringTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public Text getPrimitiveWritableObject(final Object o) {
+        return new Text(o.toString());
+    }
+
+    @Override
+    public String getPrimitiveJavaObject(final Object o) {
+        return o.toString();
+    }
+
+    @Override
+    protected String getValidatedPrimitiveJavaObject(final String fieldName) {
+        return fieldName;
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        // no-op
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToStringObjectInspector.java
@@ -20,11 +20,11 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
 
 public class IonFieldNameToStringObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, String>
+        extends AbstractFieldNameObjectInspector<String>
         implements StringObjectInspector {
 
-    public IonFieldNameToStringObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.stringTypeInfo, failOnOverflow);
+    public IonFieldNameToStringObjectInspector() {
+        super(TypeInfoFactory.stringTypeInfo);
     }
 
     @Override
@@ -40,10 +40,5 @@ public class IonFieldNameToStringObjectInspector
     @Override
     protected String getValidatedPrimitiveJavaObject(final String fieldName) {
         return fieldName;
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        // no-op
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import java.sql.Timestamp;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IonFieldNameToTimestampObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Timestamp>
+        implements TimestampObjectInspector {
+
+    public IonFieldNameToTimestampObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.timestampTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    public Timestamp getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public TimestampWritable getPrimitiveWritableObject(final Object o) {
+        return new TimestampWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+
+    @Override
+    protected Timestamp getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Timestamp.valueOf(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        // no-op
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
@@ -21,30 +21,25 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IonFieldNameToTimestampObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Timestamp>
+        extends AbstractFieldNameObjectInspector<Timestamp>
         implements TimestampObjectInspector {
 
-    public IonFieldNameToTimestampObjectInspector(final boolean failOnOverflow) {
-        super(TypeInfoFactory.timestampTypeInfo, failOnOverflow);
+    public IonFieldNameToTimestampObjectInspector() {
+        super(TypeInfoFactory.timestampTypeInfo);
     }
 
     @Override
     public Timestamp getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
     }
 
     @Override
     public TimestampWritable getPrimitiveWritableObject(final Object o) {
-        return new TimestampWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+        return new TimestampWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
     }
 
     @Override
     protected Timestamp getValidatedPrimitiveJavaObject(final String fieldName) {
         return Timestamp.valueOf(fieldName);
-    }
-
-    @Override
-    protected void validateSize(final String fieldName) {
-        // no-op
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTimestampObjectInspector.java
@@ -35,7 +35,7 @@ public class IonFieldNameToTimestampObjectInspector
         if (o instanceof Timestamp) {
             return (Timestamp) o;
         }
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
+        return getPrimitiveJavaObjectFromFieldName(o);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class IonFieldNameToTimestampObjectInspector
         if (o instanceof Timestamp) {
             return new TimestampWritable((Timestamp) o);
         }
-        return new TimestampWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new TimestampWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
@@ -20,7 +20,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.ShortWritable;
 
 public class IonFieldNameToTinyIntObjectInspector
-        extends AbstractOverflowableFieldNameObjectInspector<String, Byte>
+        extends AbstractFieldNameObjectInspector<Byte>
         implements ByteObjectInspector {
     public static final int MIN_VALUE = -128;
     public static final int MAX_VALUE = 127;
@@ -30,8 +30,23 @@ public class IonFieldNameToTinyIntObjectInspector
     }
 
     @Override
+    public byte get(final Object o) {
+        return (byte) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromFieldName(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+    }
+
+    @Override
     protected Byte getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Byte.parseByte(fieldName);
+        return Long.valueOf(fieldName).byteValue();
     }
 
     @Override
@@ -52,20 +67,5 @@ public class IonFieldNameToTinyIntObjectInspector
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java byte
         return MIN_VALUE <= value && value <= MAX_VALUE;
-    }
-
-    @Override
-    public byte get(final Object o) {
-        return (byte) getPrimitiveJavaObject(o);
-    }
-
-    @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromIonValue(o.toString());
-    }
-
-    @Override
-    public Object getPrimitiveWritableObject(final Object o) {
-        return new ShortWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.io.ShortWritable;
 public class IonFieldNameToTinyIntObjectInspector
         extends AbstractFieldNameObjectInspector<Byte>
         implements ByteObjectInspector {
-    public static final int MIN_VALUE = -128;
-    public static final int MAX_VALUE = 127;
 
     public IonFieldNameToTinyIntObjectInspector(final boolean failOnOverflow) {
         super(TypeInfoFactory.byteTypeInfo, failOnOverflow);
@@ -36,13 +34,8 @@ public class IonFieldNameToTinyIntObjectInspector
     }
 
     @Override
-    public Object getPrimitiveJavaObject(final Object o) {
-        return getPrimitiveJavaObjectFromFieldName(o.toString());
-    }
-
-    @Override
     public Object getPrimitiveWritableObject(final Object o) {
-        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o.toString()));
+        return new ShortWritable(getPrimitiveJavaObjectFromFieldName(o));
     }
 
     @Override
@@ -67,6 +60,6 @@ public class IonFieldNameToTinyIntObjectInspector
 
     private boolean validRange(final long value) {
         // runs after checking that fits in a Java byte
-        return MIN_VALUE <= value && value <= MAX_VALUE;
+        return Byte.MIN_VALUE <= value && value <= Byte.MAX_VALUE;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.ionhiveserde.objectinspectors.map;
 
+import com.amazon.ionhiveserde.objectinspectors.utils.IonPrimitiveReader;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.ShortWritable;
@@ -46,21 +47,21 @@ public class IonFieldNameToTinyIntObjectInspector
 
     @Override
     protected Byte getValidatedPrimitiveJavaObject(final String fieldName) {
-        return Long.valueOf(fieldName).byteValue();
+        try {
+            return IonPrimitiveReader.byteValue(fieldName);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
     }
 
     @Override
     protected void validateSize(final String fieldName) {
-        try {
-            long value = Long.parseLong(fieldName);
+        long value = IonPrimitiveReader.longValue(fieldName);
 
-            if (!validRange(value)) {
-                throw new IllegalArgumentException(
-                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
-            }
-        } catch (NumberFormatException e) {
+        if (!validRange(value)) {
             throw new IllegalArgumentException(
-                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+                    "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
         }
     }
 

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/map/IonFieldNameToTinyIntObjectInspector.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.map;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.ShortWritable;
+
+public class IonFieldNameToTinyIntObjectInspector
+        extends AbstractOverflowableFieldNameObjectInspector<String, Byte>
+        implements ByteObjectInspector {
+    public static final int MIN_VALUE = -128;
+    public static final int MAX_VALUE = 127;
+
+    public IonFieldNameToTinyIntObjectInspector(final boolean failOnOverflow) {
+        super(TypeInfoFactory.byteTypeInfo, failOnOverflow);
+    }
+
+    @Override
+    protected Byte getValidatedPrimitiveJavaObject(final String fieldName) {
+        return Byte.parseByte(fieldName);
+    }
+
+    @Override
+    protected void validateSize(final String fieldName) {
+        try {
+            long value = Long.parseLong(fieldName);
+
+            if (!validRange(value)) {
+                throw new IllegalArgumentException(
+                        "insufficient precision for " + value + " as " + this.typeInfo.getTypeName());
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "invalid format for " + fieldName + " as " + this.typeInfo.getTypeName());
+        }
+    }
+
+    private boolean validRange(final long value) {
+        // runs after checking that fits in a Java byte
+        return MIN_VALUE <= value && value <= MAX_VALUE;
+    }
+
+    @Override
+    public byte get(final Object o) {
+        return (byte) getPrimitiveJavaObject(o);
+    }
+
+    @Override
+    public Object getPrimitiveJavaObject(final Object o) {
+        return getPrimitiveJavaObjectFromIonValue(o.toString());
+    }
+
+    @Override
+    public Object getPrimitiveWritableObject(final Object o) {
+        return new ShortWritable(getPrimitiveJavaObjectFromIonValue(o.toString()));
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors.utils;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonTimestamp;
+import com.amazon.ion.IonType;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.system.IonSystemBuilder;
+import com.google.common.collect.ImmutableSet;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Set;
+
+public class IonPrimitiveReader {
+    private static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
+
+    // Restricted to boolean ion types
+    public static boolean booleanValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.BOOLEAN).booleanValue();
+    }
+
+    // Restricted to numeric ion types
+    public static byte byteValue(final String ionPrimitive) {
+        return (byte) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    public static BigDecimal decimalValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).bigDecimalValue();
+    }
+
+    public static double doubleValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).doubleValue();
+    }
+
+    public static float floatValue(final String ionPrimitive) {
+        return (float) buildSingleReader(ionPrimitive, CastType.NUMERIC).doubleValue();
+    }
+
+    public static int intValue(final String ionPrimitive) {
+        return (int) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    public static long longValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    public static short shortValue(final String ionPrimitive) {
+        return (short) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
+    }
+
+    // Restricted to temporal ion types
+    public static Date dateValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.TEMPORAL).dateValue();
+    }
+
+    public static Timestamp timestampValue(final String ionPrimitive) {
+        Timestamp ts = buildSingleReader(ionPrimitive, CastType.TEMPORAL).timestampValue();
+        return ts;
+    }
+
+    // No restrictions on ion type
+    public static String stringValue(final String ionPrimitive) {
+        return buildSingleReader(ionPrimitive, CastType.ALL).stringValue();
+    }
+
+
+
+    private static IonReader buildSingleReader(final String ionPrimitive, final CastType targetType) {
+        IonReader reader = SYSTEM.newReader(ionPrimitive);
+        IonType type = reader.next();
+        if (!targetType.canCast(type)) {
+            throw new IllegalArgumentException(
+                    String.format("Unable to cast value %s of type %s as %s type.",
+                            ionPrimitive,
+                            type.name(),
+                            targetType.toString().toLowerCase()));
+        }
+        return reader;
+    }
+
+    private enum CastType {
+        ALL,
+        BOOLEAN,
+        NUMERIC,
+        TEMPORAL;
+
+        private static Set<IonType> NUMERIC_TYPE = ImmutableSet.of(IonType.INT, IonType.DECIMAL, IonType.FLOAT);
+
+        public boolean canCast(final IonType type) {
+            switch (this) {
+                case ALL:
+                    return true;
+                case BOOLEAN:
+                    return type == IonType.BOOL;
+                case TEMPORAL:
+                    return type == IonType.TIMESTAMP;
+                case NUMERIC:
+                    return NUMERIC_TYPE.contains(type);
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/utils/IonPrimitiveReader.java
@@ -16,11 +16,9 @@
 package com.amazon.ionhiveserde.objectinspectors.utils;
 
 import com.amazon.ion.IonReader;
-import com.amazon.ion.IonSystem;
-import com.amazon.ion.IonTimestamp;
 import com.amazon.ion.IonType;
 import com.amazon.ion.Timestamp;
-import com.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.system.IonReaderBuilder;
 import com.google.common.collect.ImmutableSet;
 
 import java.math.BigDecimal;
@@ -28,62 +26,126 @@ import java.util.Date;
 import java.util.Set;
 
 public class IonPrimitiveReader {
-    private static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
+
+    private static final IonReaderBuilder READER_BUILDER = IonReaderBuilder.standard().immutable();
 
     // Restricted to boolean ion types
+    /**
+     * Convert a string containing a single serialized IonValue to a boolean.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return boolean value.
+     */
     public static boolean booleanValue(final String ionPrimitive) {
         return buildSingleReader(ionPrimitive, CastType.BOOLEAN).booleanValue();
     }
 
     // Restricted to numeric ion types
+    /**
+     * Convert a string containing a single serialized IonValue to a byte.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return byte value.
+     */
     public static byte byteValue(final String ionPrimitive) {
         return (byte) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to a BigDecimal.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return BigDecimal value.
+     */
     public static BigDecimal decimalValue(final String ionPrimitive) {
         return buildSingleReader(ionPrimitive, CastType.NUMERIC).bigDecimalValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to a double.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return double value.
+     */
     public static double doubleValue(final String ionPrimitive) {
         return buildSingleReader(ionPrimitive, CastType.NUMERIC).doubleValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to a float.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return float value.
+     */
     public static float floatValue(final String ionPrimitive) {
-        return (float) buildSingleReader(ionPrimitive, CastType.NUMERIC).doubleValue();
+        return (float) buildSingleReader(ionPrimitive, CastType.FLOAT).doubleValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to an int.
+     * @param ionPrimitive - - String with serialized Ion value.
+     * @return int value.
+     */
     public static int intValue(final String ionPrimitive) {
         return (int) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to a long.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return long value.
+     */
     public static long longValue(final String ionPrimitive) {
         return buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to a short.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return short value.
+     */
     public static short shortValue(final String ionPrimitive) {
         return (short) buildSingleReader(ionPrimitive, CastType.NUMERIC).longValue();
     }
 
     // Restricted to temporal ion types
+
+    /**
+     * Convert a string containing a single serialized IonValue to an Ion date.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return Ion date value.
+     */
     public static Date dateValue(final String ionPrimitive) {
         return buildSingleReader(ionPrimitive, CastType.TEMPORAL).dateValue();
     }
 
+    /**
+     * Convert a string containing a single serialized IonValue to an Ion timestamp.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return Ion timestamp value.
+     */
     public static Timestamp timestampValue(final String ionPrimitive) {
         Timestamp ts = buildSingleReader(ionPrimitive, CastType.TEMPORAL).timestampValue();
         return ts;
     }
 
     // No restrictions on ion type
+    /**
+     * Reads a single string containing a serialized IonValue as a string.
+     * @param ionPrimitive - String with serialized Ion value.
+     * @return String value containing text representation of an IonValue.
+     */
     public static String stringValue(final String ionPrimitive) {
-        return buildSingleReader(ionPrimitive, CastType.ALL).stringValue();
+        IonReader reader = READER_BUILDER.build(ionPrimitive);
+        IonType type = reader.next();
+        validateReader(ionPrimitive, type, CastType.STRING);
+        return toStringValue(reader, type, ionPrimitive);
     }
 
-
-
     private static IonReader buildSingleReader(final String ionPrimitive, final CastType targetType) {
-        IonReader reader = SYSTEM.newReader(ionPrimitive);
+        IonReader reader = READER_BUILDER.build(ionPrimitive);
         IonType type = reader.next();
+        validateReader(ionPrimitive, type, targetType);
+        return reader;
+    }
+
+    private static void validateReader(final String ionPrimitive, final IonType type, final CastType targetType) {
+
         if (!targetType.canCast(type)) {
             throw new IllegalArgumentException(
                     String.format("Unable to cast value %s of type %s as %s type.",
@@ -91,27 +153,54 @@ public class IonPrimitiveReader {
                             type.name(),
                             targetType.toString().toLowerCase()));
         }
-        return reader;
+    }
+
+    private static String toStringValue(final IonReader reader, final IonType type, final String ionPrimitive) {
+        String stringValue;
+        switch (type) {
+            case BOOL:
+                stringValue = String.valueOf(reader.booleanValue());
+                break;
+            case DECIMAL:
+                stringValue = reader.decimalValue().toString();
+                break;
+            case FLOAT:
+                stringValue = String.valueOf(reader.doubleValue());
+                break;
+            case INT:
+                stringValue = String.valueOf(reader.intValue());
+                break;
+            case TIMESTAMP:
+                stringValue = reader.timestampValue().toString();
+                break;
+            default:
+                stringValue = buildSingleReader(ionPrimitive, CastType.STRING).stringValue();
+        }
+        return stringValue;
     }
 
     private enum CastType {
-        ALL,
         BOOLEAN,
+        FLOAT,
         NUMERIC,
+        STRING,
         TEMPORAL;
 
         private static Set<IonType> NUMERIC_TYPE = ImmutableSet.of(IonType.INT, IonType.DECIMAL, IonType.FLOAT);
+        private static Set<IonType> FLOAT_TYPE = ImmutableSet.of(IonType.DECIMAL, IonType.FLOAT);
 
         public boolean canCast(final IonType type) {
             switch (this) {
-                case ALL:
-                    return true;
                 case BOOLEAN:
                     return type == IonType.BOOL;
-                case TEMPORAL:
-                    return type == IonType.TIMESTAMP;
+                case FLOAT:
+                    return FLOAT_TYPE.contains(type);
                 case NUMERIC:
                     return NUMERIC_TYPE.contains(type);
+                case STRING:
+                    return true;
+                case TEMPORAL:
+                    return type == IonType.TIMESTAMP;
                 default:
                     return false;
             }

--- a/serde/src/main/java/com/amazon/ionhiveserde/serializers/AbstractStructSerializer.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/serializers/AbstractStructSerializer.java
@@ -15,10 +15,15 @@
 
 package com.amazon.ionhiveserde.serializers;
 
+import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.system.IonTextWriterBuilder;
 import com.amazon.ionhiveserde.configuration.SerDeProperties;
 import com.amazon.ionhiveserde.configuration.SerializeNullStrategy;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
@@ -26,7 +31,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.io.Text;
 
 /**
  * Base class for struct serializers.
@@ -34,9 +39,11 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspe
 abstract class AbstractStructSerializer implements IonSerializer {
 
     private final SerDeProperties properties;
+    private final IonSystem system;
 
     AbstractStructSerializer(final SerDeProperties properties) {
         this.properties = properties;
+        this.system = IonSystemBuilder.standard().build();
     }
 
     @Override
@@ -69,11 +76,10 @@ abstract class AbstractStructSerializer implements IonSerializer {
                 .getMapKeyObjectInspector();
 
         final ObjectInspector valueObjectInspector = objectInspector.getMapValueObjectInspector();
-
         writer.stepIn(IonType.STRUCT);
 
         for (Map.Entry entry : objectInspector.getMap(data).entrySet()) {
-            final String key = keyObjectInspector.getPrimitiveJavaObject(entry.getKey()).toString();
+            String key = getKey(keyObjectInspector, entry.getKey());
             final IonSerializer ionSerializer = IonSerializerFactory.serializerForObjectInspector(
                 valueObjectInspector,
                 properties);
@@ -83,6 +89,17 @@ abstract class AbstractStructSerializer implements IonSerializer {
         }
 
         writer.stepOut();
+    }
+
+    private String getKey(final PrimitiveObjectInspector keyInspector, final Object entry)
+            throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final IonWriter keyWriter = IonTextWriterBuilder.standard().build(out);
+        final IonSerializer keySerializer = IonSerializerFactory.serializerForObjectInspector(
+                keyInspector,
+                properties);
+        serializeFieldValue(keySerializer, keyWriter, entry, keyInspector);
+        return new Text(out.toByteArray()).toString();
     }
 
     private void serializeStruct(final IonWriter writer,

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -20,7 +20,6 @@ import com.amazon.ionhiveserde.ION
 import com.amazon.ionhiveserde.ionNull
 import com.amazon.ionhiveserde.objectinspectors.map.*
 import org.apache.hadoop.hive.common.type.HiveDecimal
-import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE
 import org.junit.Test
@@ -31,7 +30,7 @@ import kotlin.test.assertNull
 import kotlin.test.fail
 
 class IonStructToMapObjectInspectorTest {
-    private val stringIntKeyElementInspector = IonFieldNameToStringObjectInspector(true)
+    private val stringIntKeyElementInspector = IonFieldNameToStringObjectInspector()
     private val stringIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val stringIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(stringIntKeyElementInspector, stringIntValueElementInspector)
 
@@ -39,7 +38,13 @@ class IonStructToMapObjectInspectorTest {
     private val intIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val intIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(intIntKeyElementInspector, intIntValueElementInspector)
 
-    private val bigintIntKeyElementInspector = IonFieldNameToBigIntObjectInspector(true)
+    private val intIntKeyElementInspectorOverflow = IonFieldNameToIntObjectInspector(false)
+    private val intIntValueElementInspectorOverflow = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val intIntSubjectOverflow = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(
+            intIntKeyElementInspectorOverflow,
+            intIntValueElementInspectorOverflow)
+
+    private val bigintIntKeyElementInspector = IonFieldNameToBigIntObjectInspector()
     private val bigintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val bigintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(bigintIntKeyElementInspector, bigintIntValueElementInspector)
 
@@ -55,23 +60,23 @@ class IonStructToMapObjectInspectorTest {
     private val floatIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val floatIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(floatIntKeyElementInspector, floatIntValueElementInspector)
 
-    private val doubleIntKeyElementInspector = IonFieldNameToDoubleObjectInspector(true)
+    private val doubleIntKeyElementInspector = IonFieldNameToDoubleObjectInspector()
     private val doubleIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val doubleIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(doubleIntKeyElementInspector, doubleIntValueElementInspector)
 
-    private val booleanIntKeyElementInspector = IonFieldNameToBooleanObjectInspector(true)
+    private val booleanIntKeyElementInspector = IonFieldNameToBooleanObjectInspector()
     private val booleanIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val booleanIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(booleanIntKeyElementInspector, booleanIntValueElementInspector)
 
-    private val decimalIntKeyElementInspector = IonFieldNameToDecimalObjectInspector(true)
+    private val decimalIntKeyElementInspector = IonFieldNameToDecimalObjectInspector()
     private val decimalIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val decimalIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(decimalIntKeyElementInspector, decimalIntValueElementInspector)
 
-    private val dateIntKeyElementInspector = IonFieldNameToDateObjectInspector(true)
+    private val dateIntKeyElementInspector = IonFieldNameToDateObjectInspector()
     private val dateIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val dateIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(dateIntKeyElementInspector, dateIntValueElementInspector)
 
-    private val timestampIntKeyElementInspector = IonFieldNameToTimestampObjectInspector(true)
+    private val timestampIntKeyElementInspector = IonFieldNameToTimestampObjectInspector()
     private val timestampIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
     private val timestampIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(timestampIntKeyElementInspector, timestampIntValueElementInspector)
 
@@ -79,6 +84,7 @@ class IonStructToMapObjectInspectorTest {
     fun getMapKeyObjectInspector() {
         assertEquals(stringIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
         assertEquals(intIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(intIntSubjectOverflow.mapKeyObjectInspector.category, PRIMITIVE)
         assertEquals(bigintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
         assertEquals(smallintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
         assertEquals(tinyintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
@@ -94,6 +100,7 @@ class IonStructToMapObjectInspectorTest {
     fun getMapValueObjectInspector() {
         assertEquals(stringIntValueElementInspector, stringIntSubject.mapValueObjectInspector)
         assertEquals(intIntValueElementInspector, intIntSubject.mapValueObjectInspector)
+        assertEquals(intIntValueElementInspectorOverflow, intIntSubjectOverflow.mapValueObjectInspector)
         assertEquals(bigintIntValueElementInspector, bigintIntSubject.mapValueObjectInspector)
         assertEquals(smallintIntValueElementInspector, smallintIntSubject.mapValueObjectInspector)
         assertEquals(tinyintIntValueElementInspector, tinyintIntSubject.mapValueObjectInspector)
@@ -120,6 +127,11 @@ class IonStructToMapObjectInspectorTest {
         assertEquals(ION.newInt(2), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("2")))
         assertEquals(ION.newInt(3), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("3")))
         assertNull(intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("4")))
+
+        assertEquals(ION.newInt(1), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("1")))
+        assertEquals(ION.newInt(2), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("2")))
+        assertEquals(ION.newInt(3), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("3")))
+        assertNull(intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("4")))
 
         val bigintIntStruct = structs[2]
         assertEquals(ION.newInt(1), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("1")))
@@ -257,7 +269,13 @@ class IonStructToMapObjectInspectorTest {
         assertEquals(ION.newInt(3), stringIntActual["c"])
 
         val intIntStruct = structs[1]
-        val intIntActual = intIntSubject.getMap(intIntStruct)
+        var intIntActual = intIntSubject.getMap(intIntStruct)
+        assertEquals(3, intIntActual.size)
+        assertEquals(ION.newInt(1), intIntActual[1])
+        assertEquals(ION.newInt(2), intIntActual[2])
+        assertEquals(ION.newInt(3), intIntActual[3])
+
+        intIntActual = intIntSubjectOverflow.getMap(intIntStruct)
         assertEquals(3, intIntActual.size)
         assertEquals(ION.newInt(1), intIntActual[1])
         assertEquals(ION.newInt(2), intIntActual[2])
@@ -343,6 +361,9 @@ class IonStructToMapObjectInspectorTest {
         assertNull(intIntSubject.getMap(null))
         assertNull(intIntSubject.getMap(ionNull))
 
+        assertNull(intIntSubjectOverflow.getMap(null))
+        assertNull(intIntSubjectOverflow.getMap(ionNull))
+
         assertNull(bigintIntSubject.getMap(null))
         assertNull(bigintIntSubject.getMap(ionNull))
 
@@ -376,6 +397,7 @@ class IonStructToMapObjectInspectorTest {
         val structs = makeStructs()
         assertEquals(3, stringIntSubject.getMapSize(structs[0]))
         assertEquals(3, intIntSubject.getMapSize(structs[1]))
+        assertEquals(3, intIntSubjectOverflow.getMapSize(structs[1]))
         assertEquals(3, bigintIntSubject.getMapSize(structs[2]))
         assertEquals(3, smallintIntSubject.getMapSize(structs[3]))
         assertEquals(3, tinyintIntSubject.getMapSize(structs[4]))
@@ -394,6 +416,9 @@ class IonStructToMapObjectInspectorTest {
 
         assertEquals(-1, intIntSubject.getMapSize(null))
         assertEquals(-1, intIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, intIntSubjectOverflow.getMapSize(null))
+        assertEquals(-1, intIntSubjectOverflow.getMapSize(ionNull))
 
         assertEquals(-1, bigintIntSubject.getMapSize(null))
         assertEquals(-1, bigintIntSubject.getMapSize(ionNull))

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -30,55 +30,38 @@ import kotlin.test.assertNull
 import kotlin.test.fail
 
 class IonStructToMapObjectInspectorTest {
-    private val stringIntKeyElementInspector = IonFieldNameToStringObjectInspector()
-    private val stringIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val stringIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(stringIntKeyElementInspector, stringIntValueElementInspector)
+    private val elementInspector = IonIntToIntObjectInspector(true)
 
-    private val intIntKeyElementInspector = IonFieldNameToIntObjectInspector(true)
-    private val intIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val intIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(intIntKeyElementInspector, intIntValueElementInspector)
+    private val stringIntSubject = IonStructToMapObjectInspector(IonFieldNameToStringObjectInspector(), elementInspector)
+    private val intIntSubject = IonStructToMapObjectInspector(IonFieldNameToIntObjectInspector(true), elementInspector)
+    private val intIntSubjectOverflow = IonStructToMapObjectInspector(IonFieldNameToIntObjectInspector(false), elementInspector)
+    private val bigintIntSubject = IonStructToMapObjectInspector(IonFieldNameToBigIntObjectInspector(), elementInspector)
+    private val smallintIntSubject = IonStructToMapObjectInspector(IonFieldNameToSmallIntObjectInspector(true), elementInspector)
+    private val tinyintIntSubject = IonStructToMapObjectInspector(IonFieldNameToTinyIntObjectInspector(true), elementInspector)
+    private val floatIntSubject = IonStructToMapObjectInspector(IonFieldNameToFloatObjectInspector(true), elementInspector)
+    private val doubleIntSubject = IonStructToMapObjectInspector(IonFieldNameToDoubleObjectInspector(), elementInspector)
+    private val booleanIntSubject = IonStructToMapObjectInspector(IonFieldNameToBooleanObjectInspector(), elementInspector)
+    private val decimalIntSubject = IonStructToMapObjectInspector(IonFieldNameToDecimalObjectInspector(), elementInspector)
+    private val dateIntSubject = IonStructToMapObjectInspector(IonFieldNameToDateObjectInspector(), elementInspector)
+    private val timestampIntSubject = IonStructToMapObjectInspector(IonFieldNameToTimestampObjectInspector(), elementInspector)
 
-    private val intIntKeyElementInspectorOverflow = IonFieldNameToIntObjectInspector(false)
-    private val intIntValueElementInspectorOverflow = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val intIntSubjectOverflow = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(
-            intIntKeyElementInspectorOverflow,
-            intIntValueElementInspectorOverflow)
 
-    private val bigintIntKeyElementInspector = IonFieldNameToBigIntObjectInspector()
-    private val bigintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val bigintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(bigintIntKeyElementInspector, bigintIntValueElementInspector)
+    private val testBigints = listOf<Long>(1L, 2L, 3L)
+    private val testBooleans = listOf<Boolean>(true, false)
+    private val testDates = listOf<Date>(
+            Date.valueOf("1991-1-1"),
+            Date.valueOf("1992-2-3"))
+    private val testDecimals = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
+    private val testDoubles = listOf<Double>(2.0, 4.0, 6.0)
+    private val testFloats = listOf<Float>(2f, 4f, 8f)
+    private val testInts = listOf<Int>(1, 2, 3)
+    private val testSmallints = listOf<Short>(1, 2, 3)
+    private val testStrings = listOf<String>("a", "b", "c")
+    private val testTimestamps = listOf<Timestamp>(
+            Timestamp.valueOf("2014-10-14 12:34:56.789"),
+            Timestamp.valueOf("2015-10-16 12:34:56.789"))
+    private val testTinyints = listOf<Byte>(1, 2, 3)
 
-    private val smallintIntKeyElementInspector = IonFieldNameToSmallIntObjectInspector(true)
-    private val smallintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val smallintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(smallintIntKeyElementInspector, smallintIntValueElementInspector)
-
-    private val tinyintIntKeyElementInspector = IonFieldNameToTinyIntObjectInspector(true)
-    private val tinyintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val tinyintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(tinyintIntKeyElementInspector, tinyintIntValueElementInspector)
-
-    private val floatIntKeyElementInspector = IonFieldNameToFloatObjectInspector(true)
-    private val floatIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val floatIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(floatIntKeyElementInspector, floatIntValueElementInspector)
-
-    private val doubleIntKeyElementInspector = IonFieldNameToDoubleObjectInspector()
-    private val doubleIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val doubleIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(doubleIntKeyElementInspector, doubleIntValueElementInspector)
-
-    private val booleanIntKeyElementInspector = IonFieldNameToBooleanObjectInspector()
-    private val booleanIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val booleanIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(booleanIntKeyElementInspector, booleanIntValueElementInspector)
-
-    private val decimalIntKeyElementInspector = IonFieldNameToDecimalObjectInspector()
-    private val decimalIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val decimalIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(decimalIntKeyElementInspector, decimalIntValueElementInspector)
-
-    private val dateIntKeyElementInspector = IonFieldNameToDateObjectInspector()
-    private val dateIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val dateIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(dateIntKeyElementInspector, dateIntValueElementInspector)
-
-    private val timestampIntKeyElementInspector = IonFieldNameToTimestampObjectInspector()
-    private val timestampIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val timestampIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(timestampIntKeyElementInspector, timestampIntValueElementInspector)
 
     @Test
     fun getMapKeyObjectInspector() {
@@ -98,96 +81,41 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapValueObjectInspector() {
-        assertEquals(stringIntValueElementInspector, stringIntSubject.mapValueObjectInspector)
-        assertEquals(intIntValueElementInspector, intIntSubject.mapValueObjectInspector)
-        assertEquals(intIntValueElementInspectorOverflow, intIntSubjectOverflow.mapValueObjectInspector)
-        assertEquals(bigintIntValueElementInspector, bigintIntSubject.mapValueObjectInspector)
-        assertEquals(smallintIntValueElementInspector, smallintIntSubject.mapValueObjectInspector)
-        assertEquals(tinyintIntValueElementInspector, tinyintIntSubject.mapValueObjectInspector)
-        assertEquals(floatIntValueElementInspector, floatIntSubject.mapValueObjectInspector)
-        assertEquals(doubleIntValueElementInspector, doubleIntSubject.mapValueObjectInspector)
-        assertEquals(booleanIntValueElementInspector, booleanIntSubject.mapValueObjectInspector)
-        assertEquals(decimalIntValueElementInspector, decimalIntSubject.mapValueObjectInspector)
-        assertEquals(dateIntValueElementInspector, dateIntSubject.mapValueObjectInspector)
-        assertEquals(timestampIntValueElementInspector, timestampIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, stringIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, intIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, intIntSubjectOverflow.mapValueObjectInspector)
+        assertEquals(elementInspector, bigintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, smallintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, tinyintIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, floatIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, doubleIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, booleanIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, decimalIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, dateIntSubject.mapValueObjectInspector)
+        assertEquals(elementInspector, timestampIntSubject.mapValueObjectInspector)
     }
 
     @Test
     fun getMapValueElement() {
         val structs = makeStructs()
-        val stringIntStruct = structs[0]
+        testGetMapValueElement(structs[0], stringIntSubject, testStrings)
+        testGetMapValueElement(structs[1], intIntSubject, testInts.map { it.toString() })
+        testGetMapValueElement(structs[1], intIntSubjectOverflow, testInts.map { it.toString() })
+        testGetMapValueElement(structs[2], bigintIntSubject, testBigints.map { it.toString() })
+        testGetMapValueElement(structs[3], smallintIntSubject, testSmallints.map { it.toString() })
+        testGetMapValueElement(structs[4], tinyintIntSubject, testTinyints.map { it.toString() })
+        testGetMapValueElement(structs[5], floatIntSubject, testFloats.map { it.toString() })
+        testGetMapValueElement(structs[6], doubleIntSubject, testDoubles.map { it.toString() })
+        testGetMapValueElement(structs[7], booleanIntSubject, testBooleans.map { it.toString() })
+        testGetMapValueElement(structs[8], decimalIntSubject, testDecimals.map { it.toString() })
+        testGetMapValueElement(structs[9], dateIntSubject, testDates.map { it.toString() })
+        testGetMapValueElement(structs[10], timestampIntSubject, testTimestamps.map { getTsKey(it) })
+    }
 
-        assertEquals(ION.newInt(1), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("a")))
-        assertEquals(ION.newInt(2), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("b")))
-        assertEquals(ION.newInt(3), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("c")))
-        assertNull(stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("d")))
-
-        val intIntStruct = structs[1]
-        assertEquals(ION.newInt(1), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("1")))
-        assertEquals(ION.newInt(2), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("2")))
-        assertEquals(ION.newInt(3), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("3")))
-        assertNull(intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("4")))
-
-        assertEquals(ION.newInt(1), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("1")))
-        assertEquals(ION.newInt(2), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("2")))
-        assertEquals(ION.newInt(3), intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("3")))
-        assertNull(intIntSubjectOverflow.getMapValueElement(intIntStruct, ION.newSymbol("4")))
-
-        val bigintIntStruct = structs[2]
-        assertEquals(ION.newInt(1), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("1")))
-        assertEquals(ION.newInt(2), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("2")))
-        assertEquals(ION.newInt(3), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("3")))
-        assertNull(bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("4")))
-
-        val smallintIntStruct = structs[3]
-        assertEquals(ION.newInt(1), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("1")))
-        assertEquals(ION.newInt(2), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("2")))
-        assertEquals(ION.newInt(3), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("3")))
-        assertNull(smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("4")))
-
-        val tinyintIntStruct = structs[4]
-        assertEquals(ION.newInt(1), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("1")))
-        assertEquals(ION.newInt(2), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("2")))
-        assertEquals(ION.newInt(3), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("3")))
-        assertNull(tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("4")))
-
-        val floatIntStruct = structs[5]
-        val floatList = listOf<Float>(2f, 4f, 8f, 16f)
-        assertEquals(ION.newInt(1), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[0].toString())))
-        assertEquals(ION.newInt(2), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[1].toString())))
-        assertEquals(ION.newInt(3), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[2].toString())))
-        assertNull(floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[3].toString())))
-
-        val doubleIntStruct = structs[6]
-        val doubleList = listOf<Double>(2.0, 4.0, 6.0, 8.0)
-        assertEquals(ION.newInt(1), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[0].toString())))
-        assertEquals(ION.newInt(2), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[1].toString())))
-        assertEquals(ION.newInt(3), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[2].toString())))
-        assertNull(doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[3].toString())))
-
-        val boolIntStruct = structs[7]
-        val boolList = listOf<Boolean>(true, false)
-        assertEquals(ION.newInt(1), booleanIntSubject.getMapValueElement(boolIntStruct, ION.newSymbol(boolList[0].toString())))
-        assertEquals(ION.newInt(2), booleanIntSubject.getMapValueElement(boolIntStruct, ION.newSymbol(boolList[1].toString())))
-
-        val decimalIntStruct = structs[8]
-        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
-        assertEquals(ION.newInt(1), decimalIntSubject.getMapValueElement(decimalIntStruct, ION.newSymbol(decimalList[0].toString())))
-        assertEquals(ION.newInt(2), decimalIntSubject.getMapValueElement(decimalIntStruct, ION.newSymbol(decimalList[1].toString())))
-
-        val dateIntStruct = structs[9]
-        val dateList = listOf<Date>(
-                Date.valueOf("1991-1-1"),
-                Date.valueOf("1992-2-3"))
-        assertEquals(ION.newInt(1), dateIntSubject.getMapValueElement(dateIntStruct, ION.newSymbol(dateList[0].toString())))
-        assertEquals(ION.newInt(2), dateIntSubject.getMapValueElement(dateIntStruct, ION.newSymbol(dateList[1].toString())))
-
-        val timestampIntStruct = structs[10]
-        val tsList = listOf<Timestamp>(
-                Timestamp.valueOf("2014-10-14 12:34:56.789"),
-                Timestamp.valueOf("2015-10-16 12:34:56.789"))
-        assertEquals(ION.newInt(1), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(getTsKey(tsList[0]))))
-        assertEquals(ION.newInt(2), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(getTsKey(tsList[1]))))
+    private fun testGetMapValueElement(struct: IonStruct, subject : IonStructToMapObjectInspector, keys: List<String>) {
+        var structVal = 1
+        keys.forEach{assertEquals(ION.newInt(structVal++), subject.getMapValueElement(struct, ION.newSymbol(it)))}
+        assertNull(subject.getMapValueElement(struct, ION.newSymbol("4")))
     }
 
     @Test
@@ -260,136 +188,49 @@ class IonStructToMapObjectInspectorTest {
     @Test
     fun getMap() {
         val structs = makeStructs()
+        testGetMaps(structs[0], stringIntSubject, testStrings)
+        testGetMaps(structs[1], intIntSubject, testInts)
+        testGetMaps(structs[1], intIntSubjectOverflow, testInts)
+        testGetMaps(structs[2], bigintIntSubject, testBigints)
+        testGetMaps(structs[3], smallintIntSubject, testSmallints)
+        testGetMaps(structs[4], tinyintIntSubject, testTinyints)
+        testGetMaps(structs[5], floatIntSubject, testFloats)
+        testGetMaps(structs[6], doubleIntSubject, testDoubles)
+        testGetMaps(structs[7], booleanIntSubject, testBooleans)
+        testGetMaps(structs[8], decimalIntSubject, testDecimals)
+        testGetMaps(structs[9], dateIntSubject, testDates)
+        testGetMaps(structs[10], timestampIntSubject, testTimestamps)
+    }
 
-        val stringIntStruct = structs[0]
-        val stringIntActual = stringIntSubject.getMap(stringIntStruct)
-        assertEquals(3, stringIntActual.size)
-        assertEquals(ION.newInt(1), stringIntActual["a"])
-        assertEquals(ION.newInt(2), stringIntActual["b"])
-        assertEquals(ION.newInt(3), stringIntActual["c"])
-
-        val intIntStruct = structs[1]
-        var intIntActual = intIntSubject.getMap(intIntStruct)
-        assertEquals(3, intIntActual.size)
-        assertEquals(ION.newInt(1), intIntActual[1])
-        assertEquals(ION.newInt(2), intIntActual[2])
-        assertEquals(ION.newInt(3), intIntActual[3])
-
-        intIntActual = intIntSubjectOverflow.getMap(intIntStruct)
-        assertEquals(3, intIntActual.size)
-        assertEquals(ION.newInt(1), intIntActual[1])
-        assertEquals(ION.newInt(2), intIntActual[2])
-        assertEquals(ION.newInt(3), intIntActual[3])
-
-        val bigintIntStruct = structs[2]
-        val bigintIntActual = bigintIntSubject.getMap(bigintIntStruct)
-        assertEquals(3, bigintIntActual.size)
-        assertEquals(ION.newInt(1), bigintIntActual[1L])
-        assertEquals(ION.newInt(2), bigintIntActual[2L])
-        assertEquals(ION.newInt(3), bigintIntActual[3L])
-
-        val smallintIntStruct = structs[3]
-        val smallintIntActual = smallintIntSubject.getMap(smallintIntStruct)
-        val smallintList = listOf<Short>(1, 2, 3)
-        assertEquals(3, smallintIntActual.size)
-        assertEquals(ION.newInt(1), smallintIntActual[smallintList[0]])
-        assertEquals(ION.newInt(2), smallintIntActual[smallintList[1]])
-        assertEquals(ION.newInt(3), smallintIntActual[smallintList[2]])
-
-        val tinyintIntStruct = structs[4]
-        val tinyintIntActual = tinyintIntSubject.getMap(tinyintIntStruct)
-        assertEquals(3, tinyintIntActual.size)
-        val tinyintList = listOf<Byte>(1, 2, 3)
-        assertEquals(ION.newInt(1), tinyintIntActual[tinyintList[0]])
-        assertEquals(ION.newInt(2), tinyintIntActual[tinyintList[1]])
-        assertEquals(ION.newInt(3), tinyintIntActual[tinyintList[2]])
-
-        val floatIntStruct = structs[5]
-        val floatIntActual = floatIntSubject.getMap(floatIntStruct)
-        assertEquals(3, floatIntActual.size)
-        val floatList = listOf<Float>(2f, 4f, 8f)
-        assertEquals(ION.newInt(1), floatIntActual[floatList[0]])
-        assertEquals(ION.newInt(2), floatIntActual[floatList[1]])
-        assertEquals(ION.newInt(3), floatIntActual[floatList[2]])
-
-        val doubleIntStruct = structs[6]
-        val doubleIntActual = doubleIntSubject.getMap(doubleIntStruct)
-        assertEquals(3, doubleIntActual.size)
-        val doubleList = listOf<Double>(2.0, 4.0, 6.0)
-        assertEquals(ION.newInt(1), doubleIntActual[doubleList[0]])
-        assertEquals(ION.newInt(2), doubleIntActual[doubleList[1]])
-        assertEquals(ION.newInt(3), doubleIntActual[doubleList[2]])
-
-        val booleanIntStruct = structs[7]
-        val booleanIntActual = booleanIntSubject.getMap(booleanIntStruct)
-        assertEquals(2, booleanIntActual.size)
-        val booleanList = listOf<Boolean>(true, false)
-        assertEquals(ION.newInt(1), booleanIntActual[booleanList[0]])
-        assertEquals(ION.newInt(2), booleanIntActual[booleanList[1]])
-
-        val decimalIntStruct = structs[8]
-        val decimalIntActual = decimalIntSubject.getMap(decimalIntStruct)
-        assertEquals(2, decimalIntActual.size)
-        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
-        assertEquals(ION.newInt(1), decimalIntActual[decimalList[0]])
-        assertEquals(ION.newInt(2), decimalIntActual[decimalList[1]])
-
-        val dateIntStruct = structs[9]
-        val dateIntActual = dateIntSubject.getMap(dateIntStruct)
-        assertEquals(2, dateIntActual.size)
-        val dateList = listOf<Date>(
-                Date.valueOf("1991-1-1"),
-                Date.valueOf("1992-2-3"))
-        assertEquals(ION.newInt(1), dateIntActual[dateList[0]])
-        assertEquals(ION.newInt(2), dateIntActual[dateList[1]])
-
-        val timestampIntStruct = structs[10]
-        val timestampIntActual = timestampIntSubject.getMap(timestampIntStruct)
-        assertEquals(2, timestampIntActual.size)
-        val tsList = listOf<Timestamp>(
-                Timestamp.valueOf("2014-10-14 12:34:56.789"),
-                Timestamp.valueOf("2015-10-16 12:34:56.789"))
-        assertEquals(ION.newInt(1), timestampIntActual[tsList[0]])
-        assertEquals(ION.newInt(2), timestampIntActual[tsList[1]])
+    private fun testGetMaps(struct : IonStruct, subject : IonStructToMapObjectInspector, keyValues : List<Any>) {
+        val map = subject.getMap(struct)
+        assertEquals(keyValues.size, map.size)
+        var ionVal = 1
+        keyValues.forEach{assertEquals(ION.newInt(ionVal++), map[it])}
     }
 
     @Test
     fun getMapForNullData() {
-        assertNull(stringIntSubject.getMap(null))
-        assertNull(stringIntSubject.getMap(ionNull))
+        testGetMapForNullData(stringIntSubject)
 
-        assertNull(intIntSubject.getMap(null))
-        assertNull(intIntSubject.getMap(ionNull))
+        testGetMapForNullData(intIntSubjectOverflow)
+        testGetMapForNullData(bigintIntSubject)
+        testGetMapForNullData(smallintIntSubject)
+        testGetMapForNullData(tinyintIntSubject)
 
-        assertNull(intIntSubjectOverflow.getMap(null))
-        assertNull(intIntSubjectOverflow.getMap(ionNull))
+        testGetMapForNullData(floatIntSubject)
+        testGetMapForNullData(doubleIntSubject)
+        testGetMapForNullData(decimalIntSubject)
 
-        assertNull(bigintIntSubject.getMap(null))
-        assertNull(bigintIntSubject.getMap(ionNull))
+        testGetMapForNullData(booleanIntSubject)
 
-        assertNull(smallintIntSubject.getMap(null))
-        assertNull(smallintIntSubject.getMap(ionNull))
+        testGetMapForNullData(dateIntSubject)
+        testGetMapForNullData(timestampIntSubject)
+    }
 
-        assertNull(tinyintIntSubject.getMap(null))
-        assertNull(tinyintIntSubject.getMap(ionNull))
-
-        assertNull(floatIntSubject.getMap(null))
-        assertNull(floatIntSubject.getMap(ionNull))
-
-        assertNull(doubleIntSubject.getMap(null))
-        assertNull(doubleIntSubject.getMap(ionNull))
-
-        assertNull(booleanIntSubject.getMap(null))
-        assertNull(booleanIntSubject.getMap(ionNull))
-
-        assertNull(decimalIntSubject.getMap(null))
-        assertNull(decimalIntSubject.getMap(ionNull))
-
-        assertNull(dateIntSubject.getMap(null))
-        assertNull(dateIntSubject.getMap(ionNull))
-
-        assertNull(timestampIntSubject.getMap(null))
-        assertNull(timestampIntSubject.getMap(ionNull))
+    private fun testGetMapForNullData(subject : IonStructToMapObjectInspector) {
+        assertNull(subject.getMap(null))
+        assertNull(subject.getMap(ionNull))
     }
 
     @Test
@@ -411,41 +252,26 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapSizeForNull() {
-        assertEquals(-1, stringIntSubject.getMapSize(null))
-        assertEquals(-1, stringIntSubject.getMapSize(ionNull))
+        testGetMapSizeForNull(stringIntSubject)
 
-        assertEquals(-1, intIntSubject.getMapSize(null))
-        assertEquals(-1, intIntSubject.getMapSize(ionNull))
+        testGetMapSizeForNull(intIntSubjectOverflow)
+        testGetMapSizeForNull(bigintIntSubject)
+        testGetMapSizeForNull(smallintIntSubject)
+        testGetMapSizeForNull(tinyintIntSubject)
 
-        assertEquals(-1, intIntSubjectOverflow.getMapSize(null))
-        assertEquals(-1, intIntSubjectOverflow.getMapSize(ionNull))
+        testGetMapSizeForNull(floatIntSubject)
+        testGetMapSizeForNull(doubleIntSubject)
+        testGetMapSizeForNull(decimalIntSubject)
 
-        assertEquals(-1, bigintIntSubject.getMapSize(null))
-        assertEquals(-1, bigintIntSubject.getMapSize(ionNull))
+        testGetMapSizeForNull(booleanIntSubject)
 
-        assertEquals(-1, smallintIntSubject.getMapSize(null))
-        assertEquals(-1, smallintIntSubject.getMapSize(ionNull))
+        testGetMapSizeForNull(dateIntSubject)
+        testGetMapSizeForNull(timestampIntSubject)
+    }
 
-        assertEquals(-1, tinyintIntSubject.getMapSize(null))
-        assertEquals(-1, tinyintIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, floatIntSubject.getMapSize(null))
-        assertEquals(-1, floatIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, doubleIntSubject.getMapSize(null))
-        assertEquals(-1, doubleIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, booleanIntSubject.getMapSize(null))
-        assertEquals(-1, booleanIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, decimalIntSubject.getMapSize(null))
-        assertEquals(-1, decimalIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, dateIntSubject.getMapSize(null))
-        assertEquals(-1, dateIntSubject.getMapSize(ionNull))
-
-        assertEquals(-1, timestampIntSubject.getMapSize(null))
-        assertEquals(-1, timestampIntSubject.getMapSize(ionNull))
+    private fun testGetMapSizeForNull(subject : IonStructToMapObjectInspector) {
+        assertEquals(-1, subject.getMapSize(null))
+        assertEquals(-1, subject.getMapSize(ionNull))
     }
 
     @Test
@@ -480,140 +306,28 @@ class IonStructToMapObjectInspectorTest {
 
     private fun makeStructs(): List<IonStruct> {
         return listOf<IonStruct>(
-                makeStringIntStruct(),
-                makeIntIntStruct(),
-                makeBigintIntStruct(),
-                makeSmallintIntStruct(),
-                makeTinyintIntStruct(),
-                makeFloatIntStruct(),
-                makeDoubleIntStruct(),
-                makeBoolIntStruct(),
-                makeDecimalIntStruct(),
-                makeDateIntStruct(),
-                makeTimestampIntStruct())
-    }
-
-    private fun makeStringIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-
-        struct.add("a", ION.newInt(1))
-        struct.add("b", ION.newInt(2))
-        struct.add("c", ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeIntIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val intList = listOf<Int>(1, 2, 3)
-
-        struct.add(intList[0].toString(), ION.newInt(1))
-        struct.add(intList[1].toString(), ION.newInt(2))
-        struct.add(intList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeBigintIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val bigintList = listOf<Long>(1L, 2L, 3L)
-
-        struct.add(bigintList[0].toString(), ION.newInt(1))
-        struct.add(bigintList[1].toString(), ION.newInt(2))
-        struct.add(bigintList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeSmallintIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val smallintList = listOf<Short>(1, 2, 3)
-
-        struct.add(smallintList[0].toString(), ION.newInt(1))
-        struct.add(smallintList[1].toString(), ION.newInt(2))
-        struct.add(smallintList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeTinyintIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val smallintList = listOf<Byte>(1, 2, 3)
-
-        struct.add(smallintList[0].toString(), ION.newInt(1))
-        struct.add(smallintList[1].toString(), ION.newInt(2))
-        struct.add(smallintList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeFloatIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val floatList = listOf<Float>(2f, 4f, 8f)
-
-        struct.add(floatList[0].toString(), ION.newInt(1))
-        struct.add(floatList[1].toString(), ION.newInt(2))
-        struct.add(floatList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeDoubleIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val doubleList = listOf<Double>(2.0, 4.0, 6.0)
-
-        struct.add(doubleList[0].toString(), ION.newInt(1))
-        struct.add(doubleList[1].toString(), ION.newInt(2))
-        struct.add(doubleList[2].toString(), ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeBoolIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val boolList = listOf<Boolean>(true, false)
-
-        struct.add(boolList[0].toString(), ION.newInt(1))
-        struct.add(boolList[1].toString(), ION.newInt(2))
-
-        return struct
-    }
-
-    private fun makeDecimalIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
-
-        struct.add(decimalList[0].toString(), ION.newInt(1))
-        struct.add(decimalList[1].toString(), ION.newInt(2))
-
-        return struct
-    }
-
-    private fun makeDateIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val dateList = listOf<Date>(
-                Date.valueOf("1991-1-1"),
-                Date.valueOf("1992-2-3"))
-
-        struct.add(dateList[0].toString(), ION.newInt(1))
-        struct.add(dateList[1].toString(), ION.newInt(2))
-
-        return struct
-    }
-
-    private fun makeTimestampIntStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-        val tsList = listOf<Timestamp>(
-                Timestamp.valueOf("2014-10-14 12:34:56.789"),
-                Timestamp.valueOf("2015-10-16 12:34:56.789"))
-        struct.add(getTsKey(tsList[0]), ION.newInt(1))
-        struct.add(getTsKey(tsList[1]), ION.newInt(2))
-
-        return struct
+                generateStruct(testStrings),
+                generateStruct(testInts.map { it.toString() }),
+                generateStruct(testBigints.map { it.toString() }),
+                generateStruct(testSmallints.map { it.toString() }),
+                generateStruct(testTinyints.map { it.toString() }),
+                generateStruct(testFloats.map { it.toString() }),
+                generateStruct(testDoubles.map { it.toString() }),
+                generateStruct(testBooleans.map { it.toString() }),
+                generateStruct(testDecimals.map { it.toString() }),
+                generateStruct(testDates.map { it.toString() }),
+                generateStruct(testTimestamps.map { getTsKey(it) }))
     }
 
     private fun getTsKey(timestamp: Timestamp): String {
         return com.amazon.ion.Timestamp.forSqlTimestampZ(timestamp).toString()
+    }
+
+    private fun generateStruct(keys : List<String>): IonStruct {
+        val struct = ION.newEmptyStruct();
+        var structVal = 1
+        keys.stream().forEach{struct.add(it, ION.newInt(structVal++))}
+        return struct
     }
 
 }

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -18,91 +18,572 @@ package com.amazon.ionhiveserde.objectinspectors
 import com.amazon.ion.IonStruct
 import com.amazon.ionhiveserde.ION
 import com.amazon.ionhiveserde.ionNull
+import com.amazon.ionhiveserde.objectinspectors.map.*
+import org.apache.hadoop.hive.common.type.HiveDecimal
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.PRIMITIVE
 import org.junit.Test
+import java.sql.Date
+import java.sql.Timestamp
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 class IonStructToMapObjectInspectorTest {
-    private val valueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
-    private val subject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(valueElementInspector)
+    private val stringIntKeyElementInspector = IonFieldNameToStringObjectInspector(true)
+    private val stringIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val stringIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(stringIntKeyElementInspector, stringIntValueElementInspector)
+
+    private val intIntKeyElementInspector = IonFieldNameToIntObjectInspector(true)
+    private val intIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val intIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(intIntKeyElementInspector, intIntValueElementInspector)
+
+    private val bigintIntKeyElementInspector = IonFieldNameToBigIntObjectInspector(true)
+    private val bigintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val bigintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(bigintIntKeyElementInspector, bigintIntValueElementInspector)
+
+    private val smallintIntKeyElementInspector = IonFieldNameToSmallIntObjectInspector(true)
+    private val smallintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val smallintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(smallintIntKeyElementInspector, smallintIntValueElementInspector)
+
+    private val tinyintIntKeyElementInspector = IonFieldNameToTinyIntObjectInspector(true)
+    private val tinyintIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val tinyintIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(tinyintIntKeyElementInspector, tinyintIntValueElementInspector)
+
+    private val floatIntKeyElementInspector = IonFieldNameToFloatObjectInspector(true)
+    private val floatIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val floatIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(floatIntKeyElementInspector, floatIntValueElementInspector)
+
+    private val doubleIntKeyElementInspector = IonFieldNameToDoubleObjectInspector(true)
+    private val doubleIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val doubleIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(doubleIntKeyElementInspector, doubleIntValueElementInspector)
+
+    private val booleanIntKeyElementInspector = IonFieldNameToBooleanObjectInspector(true)
+    private val booleanIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val booleanIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(booleanIntKeyElementInspector, booleanIntValueElementInspector)
+
+    private val decimalIntKeyElementInspector = IonFieldNameToDecimalObjectInspector(true)
+    private val decimalIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val decimalIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(decimalIntKeyElementInspector, decimalIntValueElementInspector)
+
+    private val dateIntKeyElementInspector = IonFieldNameToDateObjectInspector(true)
+    private val dateIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val dateIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(dateIntKeyElementInspector, dateIntValueElementInspector)
+
+    private val timestampIntKeyElementInspector = IonFieldNameToTimestampObjectInspector(true)
+    private val timestampIntValueElementInspector = com.amazon.ionhiveserde.objectinspectors.IonIntToIntObjectInspector(true)
+    private val timestampIntSubject = com.amazon.ionhiveserde.objectinspectors.IonStructToMapObjectInspector(timestampIntKeyElementInspector, timestampIntValueElementInspector)
 
     @Test
     fun getMapKeyObjectInspector() {
-        assertEquals(PrimitiveObjectInspectorFactory.javaStringObjectInspector, subject.mapKeyObjectInspector)
+        assertEquals(stringIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(intIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(bigintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(smallintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(tinyintIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(floatIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(doubleIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(booleanIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(decimalIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(dateIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
+        assertEquals(timestampIntSubject.mapKeyObjectInspector.category, PRIMITIVE)
     }
 
     @Test
     fun getMapValueObjectInspector() {
-        assertEquals(valueElementInspector, subject.mapValueObjectInspector)
+        assertEquals(stringIntValueElementInspector, stringIntSubject.mapValueObjectInspector)
+        assertEquals(intIntValueElementInspector, intIntSubject.mapValueObjectInspector)
+        assertEquals(bigintIntValueElementInspector, bigintIntSubject.mapValueObjectInspector)
+        assertEquals(smallintIntValueElementInspector, smallintIntSubject.mapValueObjectInspector)
+        assertEquals(tinyintIntValueElementInspector, tinyintIntSubject.mapValueObjectInspector)
+        assertEquals(floatIntValueElementInspector, floatIntSubject.mapValueObjectInspector)
+        assertEquals(doubleIntValueElementInspector, doubleIntSubject.mapValueObjectInspector)
+        assertEquals(booleanIntValueElementInspector, booleanIntSubject.mapValueObjectInspector)
+        assertEquals(decimalIntValueElementInspector, decimalIntSubject.mapValueObjectInspector)
+        assertEquals(dateIntValueElementInspector, dateIntSubject.mapValueObjectInspector)
+        assertEquals(timestampIntValueElementInspector, timestampIntSubject.mapValueObjectInspector)
     }
 
     @Test
     fun getMapValueElement() {
-        val struct = makeStruct()
+        val structs = makeStructs()
+        val stringIntStruct = structs[0]
 
-        assertEquals(ION.newInt(1), subject.getMapValueElement(struct, ION.newSymbol("a")))
-        assertEquals(ION.newInt(2), subject.getMapValueElement(struct, ION.newSymbol("b")))
-        assertEquals(ION.newInt(3), subject.getMapValueElement(struct, ION.newSymbol("c")))
-        assertNull(subject.getMapValueElement(struct, ION.newSymbol("d")))
+        assertEquals(ION.newInt(1), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("a")))
+        assertEquals(ION.newInt(2), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("b")))
+        assertEquals(ION.newInt(3), stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("c")))
+        assertNull(stringIntSubject.getMapValueElement(stringIntStruct, ION.newSymbol("d")))
+
+        val intIntStruct = structs[1]
+        assertEquals(ION.newInt(1), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("1")))
+        assertEquals(ION.newInt(2), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("2")))
+        assertEquals(ION.newInt(3), intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("3")))
+        assertNull(intIntSubject.getMapValueElement(intIntStruct, ION.newSymbol("4")))
+
+        val bigintIntStruct = structs[2]
+        assertEquals(ION.newInt(1), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("1")))
+        assertEquals(ION.newInt(2), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("2")))
+        assertEquals(ION.newInt(3), bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("3")))
+        assertNull(bigintIntSubject.getMapValueElement(bigintIntStruct, ION.newSymbol("4")))
+
+        val smallintIntStruct = structs[3]
+        assertEquals(ION.newInt(1), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("1")))
+        assertEquals(ION.newInt(2), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("2")))
+        assertEquals(ION.newInt(3), smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("3")))
+        assertNull(smallintIntSubject.getMapValueElement(smallintIntStruct, ION.newSymbol("4")))
+
+        val tinyintIntStruct = structs[4]
+        assertEquals(ION.newInt(1), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("1")))
+        assertEquals(ION.newInt(2), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("2")))
+        assertEquals(ION.newInt(3), tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("3")))
+        assertNull(tinyintIntSubject.getMapValueElement(tinyintIntStruct, ION.newSymbol("4")))
+
+        val floatIntStruct = structs[5]
+        val floatList = listOf<Float>(2f, 4f, 8f, 16f)
+        assertEquals(ION.newInt(1), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[0].toString())))
+        assertEquals(ION.newInt(2), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[1].toString())))
+        assertEquals(ION.newInt(3), floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[2].toString())))
+        assertNull(floatIntSubject.getMapValueElement(floatIntStruct, ION.newSymbol(floatList[3].toString())))
+
+        val doubleIntStruct = structs[6]
+        val doubleList = listOf<Double>(2.0, 4.0, 6.0, 8.0)
+        assertEquals(ION.newInt(1), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[0].toString())))
+        assertEquals(ION.newInt(2), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[1].toString())))
+        assertEquals(ION.newInt(3), doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[2].toString())))
+        assertNull(doubleIntSubject.getMapValueElement(doubleIntStruct, ION.newSymbol(doubleList[3].toString())))
+
+        val boolIntStruct = structs[7]
+        val boolList = listOf<Boolean>(true, false)
+        assertEquals(ION.newInt(1), booleanIntSubject.getMapValueElement(boolIntStruct, ION.newSymbol(boolList[0].toString())))
+        assertEquals(ION.newInt(2), booleanIntSubject.getMapValueElement(boolIntStruct, ION.newSymbol(boolList[1].toString())))
+
+        val decimalIntStruct = structs[8]
+        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
+        assertEquals(ION.newInt(1), decimalIntSubject.getMapValueElement(decimalIntStruct, ION.newSymbol(decimalList[0].toString())))
+        assertEquals(ION.newInt(2), decimalIntSubject.getMapValueElement(decimalIntStruct, ION.newSymbol(decimalList[1].toString())))
+
+        val dateIntStruct = structs[9]
+        val dateList = listOf<Date>(
+                Date.valueOf("1991-1-1"),
+                Date.valueOf("1992-2-3"))
+        assertEquals(ION.newInt(1), dateIntSubject.getMapValueElement(dateIntStruct, ION.newSymbol(dateList[0].toString())))
+        assertEquals(ION.newInt(2), dateIntSubject.getMapValueElement(dateIntStruct, ION.newSymbol(dateList[1].toString())))
+
+        val timestampIntStruct = structs[10]
+        val tsList = listOf<Timestamp>(
+                Timestamp.valueOf("2014-10-14 12:34:56.789"),
+                Timestamp.valueOf("2015-10-16 12:34:56.789"))
+        assertEquals(ION.newInt(1), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(tsList[0].toString())))
+        assertEquals(ION.newInt(2), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(tsList[1].toString())))
     }
 
     @Test
     fun getMapValueElementForNullData() {
-        assertNull(subject.getMapValueElement(null, ION.newSymbol("a")))
-        assertNull(subject.getMapValueElement(ionNull, ION.newSymbol("a")))
+        assertNull(stringIntSubject.getMapValueElement(null, ION.newSymbol("a")))
+        assertNull(stringIntSubject.getMapValueElement(ionNull, ION.newSymbol("a")))
+
+        assertNull(intIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(intIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(bigintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(bigintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(smallintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(smallintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        assertNull(tinyintIntSubject.getMapValueElement(null, ION.newSymbol("1")))
+        assertNull(tinyintIntSubject.getMapValueElement(ionNull, ION.newSymbol("1")))
+
+        val floatVal = 2f;
+        assertNull(floatIntSubject.getMapValueElement(null, ION.newSymbol(floatVal.toString())))
+        assertNull(floatIntSubject.getMapValueElement(ionNull, ION.newSymbol(floatVal.toString())))
+
+        val doubleVal = 2.0;
+        assertNull(doubleIntSubject.getMapValueElement(null, ION.newSymbol(doubleVal.toString())))
+        assertNull(doubleIntSubject.getMapValueElement(ionNull, ION.newSymbol(doubleVal.toString())))
+
+        // No boolean check here because both true and false are already used
+
+        val decimalVal = HiveDecimal.create(3)
+        assertNull(decimalIntSubject.getMapValueElement(null, ION.newSymbol(decimalVal.toString())))
+        assertNull(decimalIntSubject.getMapValueElement(ionNull, ION.newSymbol(decimalVal.toString())))
+
+        val dateVal = Date.valueOf("1998-1-2")
+        assertNull(dateIntSubject.getMapValueElement(null, ION.newSymbol(dateVal.toString())))
+        assertNull(dateIntSubject.getMapValueElement(ionNull, ION.newSymbol(dateVal.toString())))
+
+        val timestampVal = Timestamp.valueOf("2015-10-16 12:34:56.887")
+        assertNull(timestampIntSubject.getMapValueElement(null, ION.newSymbol(timestampVal.toString())))
+        assertNull(timestampIntSubject.getMapValueElement(ionNull, ION.newSymbol(timestampVal.toString())))
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun getMapValueElementForNullKey() {
-        assertNull(subject.getMapValueElement(makeStruct(), null))
+        val structs = makeStructs()
+        assertNullThrowsIllegalArgumentException(stringIntSubject, structs[0])
+        assertNullThrowsIllegalArgumentException(intIntSubject, structs[1])
+        assertNullThrowsIllegalArgumentException(bigintIntSubject, structs[2])
+        assertNullThrowsIllegalArgumentException(smallintIntSubject, structs[3])
+        assertNullThrowsIllegalArgumentException(tinyintIntSubject, structs[4])
+        assertNullThrowsIllegalArgumentException(floatIntSubject, structs[5])
+        assertNullThrowsIllegalArgumentException(doubleIntSubject, structs[6])
+        assertNullThrowsIllegalArgumentException(booleanIntSubject, structs[7])
+        assertNullThrowsIllegalArgumentException(decimalIntSubject, structs[8])
+        assertNullThrowsIllegalArgumentException(dateIntSubject, structs[9])
+        assertNullThrowsIllegalArgumentException(timestampIntSubject, structs[10])
+    }
+
+    private fun assertNullThrowsIllegalArgumentException (subject: IonStructToMapObjectInspector, struct: IonStruct) {
+        try {
+            assertNull(subject.getMapValueElement(struct, null))
+            fail("IllegalArgumentException expected")
+        } catch (e: IllegalArgumentException ) {
+            // success
+        } catch (e: Exception) {
+            fail("Expected IllegalArgumentException, caught $e")
+        }
     }
 
     @Test
     fun getMap() {
-        val struct = makeStruct()
+        val structs = makeStructs()
 
-        val actual = subject.getMap(struct)
-        assertEquals(3, actual.size)
-        assertEquals(ION.newInt(1), actual["a"])
-        assertEquals(ION.newInt(2), actual["b"])
-        assertEquals(ION.newInt(3), actual["c"])
+        val stringIntStruct = structs[0]
+        val stringIntActual = stringIntSubject.getMap(stringIntStruct)
+        assertEquals(3, stringIntActual.size)
+        assertEquals(ION.newInt(1), stringIntActual["a"])
+        assertEquals(ION.newInt(2), stringIntActual["b"])
+        assertEquals(ION.newInt(3), stringIntActual["c"])
+
+        val intIntStruct = structs[1]
+        val intIntActual = intIntSubject.getMap(intIntStruct)
+        assertEquals(3, intIntActual.size)
+        assertEquals(ION.newInt(1), intIntActual[1])
+        assertEquals(ION.newInt(2), intIntActual[2])
+        assertEquals(ION.newInt(3), intIntActual[3])
+
+        val bigintIntStruct = structs[2]
+        val bigintIntActual = bigintIntSubject.getMap(bigintIntStruct)
+        assertEquals(3, bigintIntActual.size)
+        assertEquals(ION.newInt(1), bigintIntActual[1L])
+        assertEquals(ION.newInt(2), bigintIntActual[2L])
+        assertEquals(ION.newInt(3), bigintIntActual[3L])
+
+        val smallintIntStruct = structs[3]
+        val smallintIntActual = smallintIntSubject.getMap(smallintIntStruct)
+        val smallintList = listOf<Short>(1, 2, 3)
+        assertEquals(3, smallintIntActual.size)
+        assertEquals(ION.newInt(1), smallintIntActual[smallintList[0]])
+        assertEquals(ION.newInt(2), smallintIntActual[smallintList[1]])
+        assertEquals(ION.newInt(3), smallintIntActual[smallintList[2]])
+
+        val tinyintIntStruct = structs[4]
+        val tinyintIntActual = tinyintIntSubject.getMap(tinyintIntStruct)
+        assertEquals(3, tinyintIntActual.size)
+        val tinyintList = listOf<Byte>(1, 2, 3)
+        assertEquals(ION.newInt(1), tinyintIntActual[tinyintList[0]])
+        assertEquals(ION.newInt(2), tinyintIntActual[tinyintList[1]])
+        assertEquals(ION.newInt(3), tinyintIntActual[tinyintList[2]])
+
+        val floatIntStruct = structs[5]
+        val floatIntActual = floatIntSubject.getMap(floatIntStruct)
+        assertEquals(3, floatIntActual.size)
+        val floatList = listOf<Float>(2f, 4f, 8f)
+        assertEquals(ION.newInt(1), floatIntActual[floatList[0]])
+        assertEquals(ION.newInt(2), floatIntActual[floatList[1]])
+        assertEquals(ION.newInt(3), floatIntActual[floatList[2]])
+
+        val doubleIntStruct = structs[6]
+        val doubleIntActual = doubleIntSubject.getMap(doubleIntStruct)
+        assertEquals(3, doubleIntActual.size)
+        val doubleList = listOf<Double>(2.0, 4.0, 6.0)
+        assertEquals(ION.newInt(1), doubleIntActual[doubleList[0]])
+        assertEquals(ION.newInt(2), doubleIntActual[doubleList[1]])
+        assertEquals(ION.newInt(3), doubleIntActual[doubleList[2]])
+
+        val booleanIntStruct = structs[7]
+        val booleanIntActual = booleanIntSubject.getMap(booleanIntStruct)
+        assertEquals(2, booleanIntActual.size)
+        val booleanList = listOf<Boolean>(true, false)
+        assertEquals(ION.newInt(1), booleanIntActual[booleanList[0]])
+        assertEquals(ION.newInt(2), booleanIntActual[booleanList[1]])
+
+        val decimalIntStruct = structs[8]
+        val decimalIntActual = decimalIntSubject.getMap(decimalIntStruct)
+        assertEquals(2, decimalIntActual.size)
+        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
+        assertEquals(ION.newInt(1), decimalIntActual[decimalList[0]])
+        assertEquals(ION.newInt(2), decimalIntActual[decimalList[1]])
+
+        val dateIntStruct = structs[9]
+        val dateIntActual = dateIntSubject.getMap(dateIntStruct)
+        assertEquals(2, dateIntActual.size)
+        val dateList = listOf<Date>(
+                Date.valueOf("1991-1-1"),
+                Date.valueOf("1992-2-3"))
+        assertEquals(ION.newInt(1), dateIntActual[dateList[0]])
+        assertEquals(ION.newInt(2), dateIntActual[dateList[1]])
+
+        val timestampIntStruct = structs[10]
+        val timestampIntActual = timestampIntSubject.getMap(timestampIntStruct)
+        assertEquals(2, timestampIntActual.size)
+        val tsList = listOf<Timestamp>(
+                Timestamp.valueOf("2014-10-14 12:34:56.789"),
+                Timestamp.valueOf("2015-10-16 12:34:56.789"))
+        assertEquals(ION.newInt(1), timestampIntActual[tsList[0]])
+        assertEquals(ION.newInt(2), timestampIntActual[tsList[1]])
     }
 
     @Test
     fun getMapForNullData() {
-        assertNull(subject.getMap(null))
-        assertNull(subject.getMap(ionNull))
+        assertNull(stringIntSubject.getMap(null))
+        assertNull(stringIntSubject.getMap(ionNull))
+
+        assertNull(intIntSubject.getMap(null))
+        assertNull(intIntSubject.getMap(ionNull))
+
+        assertNull(bigintIntSubject.getMap(null))
+        assertNull(bigintIntSubject.getMap(ionNull))
+
+        assertNull(smallintIntSubject.getMap(null))
+        assertNull(smallintIntSubject.getMap(ionNull))
+
+        assertNull(tinyintIntSubject.getMap(null))
+        assertNull(tinyintIntSubject.getMap(ionNull))
+
+        assertNull(floatIntSubject.getMap(null))
+        assertNull(floatIntSubject.getMap(ionNull))
+
+        assertNull(doubleIntSubject.getMap(null))
+        assertNull(doubleIntSubject.getMap(ionNull))
+
+        assertNull(booleanIntSubject.getMap(null))
+        assertNull(booleanIntSubject.getMap(ionNull))
+
+        assertNull(decimalIntSubject.getMap(null))
+        assertNull(decimalIntSubject.getMap(ionNull))
+
+        assertNull(dateIntSubject.getMap(null))
+        assertNull(dateIntSubject.getMap(ionNull))
+
+        assertNull(timestampIntSubject.getMap(null))
+        assertNull(timestampIntSubject.getMap(ionNull))
     }
 
     @Test
     fun getMapSize() {
-        assertEquals(3, subject.getMapSize(makeStruct()))
+        val structs = makeStructs()
+        assertEquals(3, stringIntSubject.getMapSize(structs[0]))
+        assertEquals(3, intIntSubject.getMapSize(structs[1]))
+        assertEquals(3, bigintIntSubject.getMapSize(structs[2]))
+        assertEquals(3, smallintIntSubject.getMapSize(structs[3]))
+        assertEquals(3, tinyintIntSubject.getMapSize(structs[4]))
+        assertEquals(3, floatIntSubject.getMapSize(structs[5]))
+        assertEquals(3, doubleIntSubject.getMapSize(structs[6]))
+        assertEquals(2, booleanIntSubject.getMapSize(structs[7]))
+        assertEquals(2, decimalIntSubject.getMapSize(structs[8]))
+        assertEquals(2, dateIntSubject.getMapSize(structs[9]))
+        assertEquals(2, timestampIntSubject.getMapSize(structs[10]))
     }
 
     @Test
     fun getMapSizeForNull() {
-        assertEquals(-1, subject.getMapSize(null))
-        assertEquals(-1, subject.getMapSize(ionNull))
+        assertEquals(-1, stringIntSubject.getMapSize(null))
+        assertEquals(-1, stringIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, intIntSubject.getMapSize(null))
+        assertEquals(-1, intIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, bigintIntSubject.getMapSize(null))
+        assertEquals(-1, bigintIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, smallintIntSubject.getMapSize(null))
+        assertEquals(-1, smallintIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, tinyintIntSubject.getMapSize(null))
+        assertEquals(-1, tinyintIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, floatIntSubject.getMapSize(null))
+        assertEquals(-1, floatIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, doubleIntSubject.getMapSize(null))
+        assertEquals(-1, doubleIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, booleanIntSubject.getMapSize(null))
+        assertEquals(-1, booleanIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, decimalIntSubject.getMapSize(null))
+        assertEquals(-1, decimalIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, dateIntSubject.getMapSize(null))
+        assertEquals(-1, dateIntSubject.getMapSize(ionNull))
+
+        assertEquals(-1, timestampIntSubject.getMapSize(null))
+        assertEquals(-1, timestampIntSubject.getMapSize(ionNull))
     }
 
     @Test
     fun getTypeName() {
-        assertEquals("map<string,int>", subject.typeName)
+        assertEquals("map<string,int>", stringIntSubject.typeName)
+        assertEquals("map<int,int>", intIntSubject.typeName)
+        assertEquals("map<bigint,int>", bigintIntSubject.typeName)
+        assertEquals("map<smallint,int>", smallintIntSubject.typeName)
+        assertEquals("map<tinyint,int>", tinyintIntSubject.typeName)
+        assertEquals("map<float,int>", floatIntSubject.typeName)
+        assertEquals("map<double,int>", doubleIntSubject.typeName)
+        assertEquals("map<boolean,int>", booleanIntSubject.typeName)
+        assertEquals("map<decimal(38,18),int>", decimalIntSubject.typeName)
+        assertEquals("map<date,int>", dateIntSubject.typeName)
+        assertEquals("map<timestamp,int>", timestampIntSubject.typeName)
     }
 
     @Test
     fun getCategory() {
-        assertEquals(MAP, subject.category)
+        assertEquals(MAP, stringIntSubject.category)
+        assertEquals(MAP, intIntSubject.category)
+        assertEquals(MAP, bigintIntSubject.category)
+        assertEquals(MAP, smallintIntSubject.category)
+        assertEquals(MAP, tinyintIntSubject.category)
+        assertEquals(MAP, floatIntSubject.category)
+        assertEquals(MAP, doubleIntSubject.category)
+        assertEquals(MAP, booleanIntSubject.category)
+        assertEquals(MAP, decimalIntSubject.category)
+        assertEquals(MAP, dateIntSubject.category)
+        assertEquals(MAP, timestampIntSubject.category)
     }
 
-    private fun makeStruct(): IonStruct {
+    private fun makeStructs(): List<IonStruct> {
+        return listOf<IonStruct>(
+                makeStringIntStruct(),
+                makeIntIntStruct(),
+                makeBigintIntStruct(),
+                makeSmallintIntStruct(),
+                makeTinyintIntStruct(),
+                makeFloatIntStruct(),
+                makeDoubleIntStruct(),
+                makeBoolIntStruct(),
+                makeDecimalIntStruct(),
+                makeDateIntStruct(),
+                makeTimestampIntStruct())
+    }
+
+    private fun makeStringIntStruct(): IonStruct {
         val struct = ION.newEmptyStruct()
 
         struct.add("a", ION.newInt(1))
         struct.add("b", ION.newInt(2))
         struct.add("c", ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeIntIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val intList = listOf<Int>(1, 2, 3)
+
+        struct.add(intList[0].toString(), ION.newInt(1))
+        struct.add(intList[1].toString(), ION.newInt(2))
+        struct.add(intList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeBigintIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val bigintList = listOf<Long>(1L, 2L, 3L)
+
+        struct.add(bigintList[0].toString(), ION.newInt(1))
+        struct.add(bigintList[1].toString(), ION.newInt(2))
+        struct.add(bigintList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeSmallintIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val smallintList = listOf<Short>(1, 2, 3)
+
+        struct.add(smallintList[0].toString(), ION.newInt(1))
+        struct.add(smallintList[1].toString(), ION.newInt(2))
+        struct.add(smallintList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeTinyintIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val smallintList = listOf<Byte>(1, 2, 3)
+
+        struct.add(smallintList[0].toString(), ION.newInt(1))
+        struct.add(smallintList[1].toString(), ION.newInt(2))
+        struct.add(smallintList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeFloatIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val floatList = listOf<Float>(2f, 4f, 8f)
+
+        struct.add(floatList[0].toString(), ION.newInt(1))
+        struct.add(floatList[1].toString(), ION.newInt(2))
+        struct.add(floatList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeDoubleIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val doubleList = listOf<Double>(2.0, 4.0, 6.0)
+
+        struct.add(doubleList[0].toString(), ION.newInt(1))
+        struct.add(doubleList[1].toString(), ION.newInt(2))
+        struct.add(doubleList[2].toString(), ION.newInt(3))
+
+        return struct
+    }
+
+    private fun makeBoolIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val boolList = listOf<Boolean>(true, false)
+
+        struct.add(boolList[0].toString(), ION.newInt(1))
+        struct.add(boolList[1].toString(), ION.newInt(2))
+
+        return struct
+    }
+
+    private fun makeDecimalIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val decimalList = listOf<HiveDecimal>(HiveDecimal.create(1), HiveDecimal.create(2))
+
+        struct.add(decimalList[0].toString(), ION.newInt(1))
+        struct.add(decimalList[1].toString(), ION.newInt(2))
+
+        return struct
+    }
+
+    private fun makeDateIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val dateList = listOf<Date>(
+                Date.valueOf("1991-1-1"),
+                Date.valueOf("1992-2-3"))
+
+        struct.add(dateList[0].toString(), ION.newInt(1))
+        struct.add(dateList[1].toString(), ION.newInt(2))
+
+        return struct
+    }
+
+    private fun makeTimestampIntStruct(): IonStruct {
+        val struct = ION.newEmptyStruct()
+        val tsList = listOf<Timestamp>(
+                Timestamp.valueOf("2014-10-14 12:34:56.789"),
+                Timestamp.valueOf("2015-10-16 12:34:56.789"))
+
+        struct.add(tsList[0].toString(), ION.newInt(1))
+        struct.add(tsList[1].toString(), ION.newInt(2))
 
         return struct
     }

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -186,8 +186,8 @@ class IonStructToMapObjectInspectorTest {
         val tsList = listOf<Timestamp>(
                 Timestamp.valueOf("2014-10-14 12:34:56.789"),
                 Timestamp.valueOf("2015-10-16 12:34:56.789"))
-        assertEquals(ION.newInt(1), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(tsList[0].toString())))
-        assertEquals(ION.newInt(2), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(tsList[1].toString())))
+        assertEquals(ION.newInt(1), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(getTsKey(tsList[0]))))
+        assertEquals(ION.newInt(2), timestampIntSubject.getMapValueElement(timestampIntStruct, ION.newSymbol(getTsKey(tsList[1]))))
     }
 
     @Test
@@ -246,11 +246,11 @@ class IonStructToMapObjectInspectorTest {
         assertNullThrowsIllegalArgumentException(timestampIntSubject, structs[10])
     }
 
-    private fun assertNullThrowsIllegalArgumentException (subject: IonStructToMapObjectInspector, struct: IonStruct) {
+    private fun assertNullThrowsIllegalArgumentException(subject: IonStructToMapObjectInspector, struct: IonStruct) {
         try {
             assertNull(subject.getMapValueElement(struct, null))
             fail("IllegalArgumentException expected")
-        } catch (e: IllegalArgumentException ) {
+        } catch (e: IllegalArgumentException) {
             // success
         } catch (e: Exception) {
             fail("Expected IllegalArgumentException, caught $e")
@@ -606,11 +606,14 @@ class IonStructToMapObjectInspectorTest {
         val tsList = listOf<Timestamp>(
                 Timestamp.valueOf("2014-10-14 12:34:56.789"),
                 Timestamp.valueOf("2015-10-16 12:34:56.789"))
-
-        struct.add(tsList[0].toString(), ION.newInt(1))
-        struct.add(tsList[1].toString(), ION.newInt(2))
+        struct.add(getTsKey(tsList[0]), ION.newInt(1))
+        struct.add(getTsKey(tsList[1]), ION.newInt(2))
 
         return struct
+    }
+
+    private fun getTsKey(timestamp: Timestamp): String {
+        return com.amazon.ion.Timestamp.forSqlTimestampZ(timestamp).toString()
     }
 
 }


### PR DESCRIPTION
This PR allows for all hive primitive types to be used as keys in Hive maps. Since Ion requires that all keys be symbols, we first convert the hive primitive to a string, that can then be included as a symbol when serialized to Ion. During deserialization, the object inspectors will read the field name and parse the Hive/java primitive object from the string.

Use Case and Example:

The serde serializes Hive maps as Ion structs, using the key values as struct keys.
```
MAP<STRING, STRING>
["a", "b", "c"]
["value1", "value2", "value3"]
```

Gets serialized in Ion as 
`{'a':"value1", 'b':"value2", 'c':"value3"}`

Hive maps can use any primitive type as a key value for its map type. Since Ion struct keys are symbols, this issue manifests itself when the Hive primitive used as a key is not a type that is natively converted to IonText, like if the schema has a MAP<INT, STR>. If such a schema is passed in currently, the serde will throw an error during the write. While this is not an issue if the data is externally generated in Ion natively and just being read via the serde, it does limit the generation of new data, whether it is being inserted as a value or being copied from an existing table (stored in another format).

With this PR, instead of an error being thrown, the data will first be converted to a string before being converted to a symbol.
For example:

```
MAP<INT, STR>
[1, 2, 3]
["value1", "value2", "value3"]
```

will now get serialized as 

```
{'1':"value1", '2':"value2", '3':"value3"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
