### PR TITLE
Migrates ion-hive-serde to ion-hive2-serde.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, hive2 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, hive2 ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## Amazon Ion Hive Serde
+## Amazon Ion Hive2 Serde
 
-A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format.
+An Apache Hive SerDe (short for serializer/deserializer) for the Ion file format, this package supports Hive 2.
 
 [![Build Sttus](https://github.com/amzn/ion-hive-serde/actions/workflows/main.yml/badge.svg?branch=hive2)](https://github.com/amzn/ion-hive-serde/actions?query=branch%3Ahive2+)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde)
-[![javadoc.io](https://javadoc.io/badge/com.amazon.ion/ion-hive-serde/javadoc.io.svg)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
+[![javadoc.io](https://javadoc.io/badge2/com.amazon.ion/ion-hive-serde/javadoc.io.svg)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
 
 ### Features
 * Read data stored in Ion format both binary and text.
@@ -16,7 +16,7 @@ for more information.
 * Configurable through [SerDe properties](docs/serde-properties.md).
 
 ### Installation
-Download the latest `ion-hive-serde-all-<version-number>.jar` from [https://github.com/amzn/ion-hive-serde/releases]
+Download the latest `ion-hive2-serde-all-<version-number>.jar` from [https://github.com/amzn/ion-hive-serde/releases]
 and place the JARs into `hive/lib` or use `ADD JAR` in Hive. That jar contains the SerDe and all its dependencies.
 
 To build it locally run :`./gradlew :serde:singleJar`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An Apache Hive SerDe (short for serializer/deserializer) for the Ion file format, this package supports Hive 2.
 
-[![Build Sttus](https://github.com/amzn/ion-hive-serde/actions/workflows/main.yml/badge.svg?branch=hive2)](https://github.com/amzn/ion-hive-serde/actions?query=branch%3Ahive2+)
+[![Build Status](https://github.com/amzn/ion-hive-serde/actions/workflows/main.yml/badge.svg?branch=hive2)](https://github.com/amzn/ion-hive-serde/actions?query=branch%3Ahive2+)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde)
 [![javadoc.io](https://javadoc.io/badge2/com.amazon.ion/ion-hive-serde/javadoc.io.svg)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format.
 
-[![Build Status](https://travis-ci.org/amzn/ion-hive-serde.svg?branch=master)](https://travis-ci.org/amzn/ion-hive-serde)
+[![Build Sttus](https://github.com/amzn/ion-hive-serde/actions/workflows/main.yml/badge.svg?branch=hive2)](https://github.com/amzn/ion-hive-serde/actions?query=branch%3Ahive2+)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde)
-[![Javadoc](https://javadoc-badge.appspot.com/com.amazon.ion/ion-hive-serde.svg?label=javadoc)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
+[![javadoc.io](https://javadoc.io/badge/com.amazon.ion/ion-hive-serde/javadoc.io.svg)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
 
 ### Features
 * Read data stored in Ion format both binary and text.

--- a/serde/build.gradle
+++ b/serde/build.gradle
@@ -59,7 +59,7 @@ publishing {
                 name = "Ion Hive SerDe"
                 packaging = "jar"
                 url = "https://github.com/amzn/ion-hive-serde"
-                description = "A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format."
+                description = "An Apache Hive SerDe (short for serializer/deserializer) for the Ion file format."
                 scm {
                     connection = "scm:git@github.com:amzn/ion-hive-serde.git"
                     developerConnection = "scm:git@github.com:amzn/ion-hive-serde.git"


### PR DESCRIPTION
Open this PR to start migrating ion-hive-serde to ion-hive2-serde. There are still things need to be updated. For example we need to upload new ion-hive2-serde to Maven and update the corresponding maven badge link below.

Changes:
1. Fixes badges
2. Enables GitHub actions for hive2 branch
3. Fixes README.md


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
