### PR TITLE
Migrates to ion-hive3-serde.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, hive3 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, hive3 ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-## Amazon Ion Hive Serde
+## Amazon Ion Hive3 Serde
 
-A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format.
+An Apache Hive SerDe (short for serializer/deserializer) for the Ion file format, this package supports Hive 3. 
 
-[![Build Status](https://travis-ci.org/amzn/ion-hive-serde.svg?branch=master)](https://travis-ci.org/amzn/ion-hive-serde)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive-serde)
-[![Javadoc](https://javadoc-badge.appspot.com/com.amazon.ion/ion-hive-serde.svg?label=javadoc)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive-serde)
+[![Build Status](https://github.com/amzn/ion-hive-serde/actions/workflows/main.yml/badge.svg?branch=hive3)](https://github.com/amzn/ion-hive-serde/actions?query=branch%3Ahive2+)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive3-serde/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.ion/ion-hive3-serde)
+[![javadoc.io](https://javadoc.io/badge2/com.amazon.ion/ion-hive3-serde/javadoc.io.svg)](http://www.javadoc.io/doc/com.amazon.ion/ion-hive3-serde)
 
 ### Features
 * Read data stored in Ion format both binary and text.
@@ -16,7 +16,7 @@ for more information.
 * Configurable through [SerDe properties](docs/serde-properties.md).
 
 ### Installation
-Download the latest `ion-hive-serde-all-<version-number>.jar` from [https://github.com/amzn/ion-hive-serde/releases]
+Download the latest `ion-hive3-serde-all-<version-number>.jar` from [https://github.com/amzn/ion-hive-serde/releases]
 and place the JARs into `hive/lib` or use `ADD JAR` in Hive. That jar contains the SerDe and all its dependencies.
 
 To build it locally run :`./gradlew :serde:singleJar`

--- a/serde/build.gradle
+++ b/serde/build.gradle
@@ -59,7 +59,7 @@ publishing {
                 name = "Ion Hive SerDe"
                 packaging = "jar"
                 url = "https://github.com/amzn/ion-hive-serde"
-                description = "A Apache Hive SerDe (short for serializer/deserializer) for the Ion file format."
+                description = "An Apache Hive SerDe (short for serializer/deserializer) for the Ion file format."
                 scm {
                     connection = "scm:git@github.com:amzn/ion-hive-serde.git"
                     developerConnection = "scm:git@github.com:amzn/ion-hive-serde.git"


### PR DESCRIPTION
Migrates to ion-hive3-serde.

**Changes:**

1. Fixes badges
2. Enables GitHub actions for hive3 branch
3. Fixes README.md (ion-hive-serde -> ion-hive3-serde)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
