### PR TITLE
Fixes an IonStructToMap object inspector NPE

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonCaseInsensitiveDecorator.java
@@ -22,11 +22,11 @@ import com.amazon.ion.IonValue;
 public class IonCaseInsensitiveDecorator {
     /**
      * Wraps an IonValue in an IonContainerCaseInsensitiveDecorator if it's an ion container.
-
+     *
      * @return a case insensitive decorator wrapped Ion Value.
      */
     public static IonValue wrapValue(final IonValue v) {
-        if (v == null || v.isNullValue()) {
+        if (v == null) {
             return null;
         }
 

--- a/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java
@@ -69,11 +69,8 @@ class PathExtractionConfig {
             final BiFunction<IonReader, IonStruct, Integer> callback = (ionReader, struct) -> {
                 final IonValue ionValue = struct.getSystem().newValue(ionReader);
 
-                if (ionValue.isNullValue()) {
-                    struct.put(columnName, null); // Hive can't handle IonNull
-                } else {
-                    struct.put(columnName, ionValue);
-                }
+                // Hive can't handle IonNull, and we will filter all IonNull later in object inspectors
+                struct.put(columnName, ionValue);
 
                 return 0;
             };

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
@@ -19,11 +19,11 @@ import static com.amazon.ionhiveserde.objectinspectors.IonUtil.isIonNull;
 import static org.apache.hadoop.hive.serde.serdeConstants.LIST_TYPE_NAME;
 
 import com.amazon.ion.IonSequence;
-import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonValue;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
@@ -56,8 +56,8 @@ public class IonSequenceToListObjectInspector implements ListObjectInspector {
         if (index < 0 || sequence.size() <= index) {
             return null;
         }
-        IonValue v = sequence.get(index);
-        return isIonNull(v) ? null : v;
+
+        return IonUtil.handleNull(sequence.get(index));
     }
 
     @Override
@@ -77,18 +77,7 @@ public class IonSequenceToListObjectInspector implements ListObjectInspector {
         }
 
         final IonSequence sequence = (IonSequence) data;
-        final List<IonValue> list = new ArrayList<>(sequence.size());
-
-        for (IonValue v : sequence) {
-            if (!IonUtil.isIonNull(v)) {
-                list.add(v);
-            } else {
-                // Hive can't handle Ion null
-                list.add(null);
-            }
-        }
-
-        return list;
+        return sequence.stream().map(IonUtil::handleNull).collect(Collectors.toList());
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
@@ -19,7 +19,10 @@ import static com.amazon.ionhiveserde.objectinspectors.IonUtil.isIonNull;
 import static org.apache.hadoop.hive.serde.serdeConstants.LIST_TYPE_NAME;
 
 import com.amazon.ion.IonSequence;
+import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonValue;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -73,7 +76,19 @@ public class IonSequenceToListObjectInspector implements ListObjectInspector {
             return null;
         }
 
-        return (IonSequence) data;
+        final IonSequence sequence = (IonSequence) data;
+        final List<IonValue> list = new ArrayList<>(sequence.size());
+
+        for (IonValue v : sequence) {
+            if (!IonUtil.isIonNull(v)) {
+                list.add(v);
+            } else {
+                // Hive can't handle Ion null
+                list.add(null);
+            }
+        }
+
+        return list;
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspector.java
@@ -56,8 +56,8 @@ public class IonSequenceToListObjectInspector implements ListObjectInspector {
         if (index < 0 || sequence.size() <= index) {
             return null;
         }
-
-        return sequence.get(index);
+        IonValue v = sequence.get(index);
+        return isIonNull(v) ? null : v;
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
@@ -82,18 +82,15 @@ public class IonStructToMapObjectInspector implements MapObjectInspector {
         for (IonValue v : struct) {
             if (!IonUtil.isIonNull(v)) {
                 map.put(v.getFieldName(), v);
+            } else {
+                // Hive can't handle Ion null
+                map.put(v.getFieldName(), null);
             }
         }
 
         return map;
     }
 
-    /**
-     * Return the size of data (Ion struct). Note that it's not the size of the final Map passed to upper layer as
-     * Ion null will be removed during conversion.
-     *
-     * @return size of the original struct
-     */
     @Override
     public int getMapSize(final Object data) {
         if (IonUtil.isIonNull((IonValue) data)) {

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
@@ -62,8 +62,9 @@ public class IonStructToMapObjectInspector implements MapObjectInspector {
 
         final IonStruct struct = (IonStruct) data;
         final IonSymbol symbol = (IonSymbol) key;
+        IonValue v = struct.get(symbol.stringValue());
 
-        return struct.get(symbol.stringValue());
+        return IonUtil.isIonNull(v) ? null : v;
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
@@ -80,12 +80,20 @@ public class IonStructToMapObjectInspector implements MapObjectInspector {
 
         final Map<String, IonValue> map = new HashMap<>(size, DEFAULT_LOAD_FACTOR);
         for (IonValue v : struct) {
-            map.put(v.getFieldName(), v);
+            if (!IonUtil.isIonNull(v)) {
+                map.put(v.getFieldName(), v);
+            }
         }
 
         return map;
     }
 
+    /**
+     * Return the size of data (Ion struct). Note that it's not the size of the final Map passed to upper layer as
+     * Ion null will be removed during conversion.
+     *
+     * @return size of the original struct
+     */
     @Override
     public int getMapSize(final Object data) {
         if (IonUtil.isIonNull((IonValue) data)) {

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java
@@ -22,6 +22,9 @@ import com.amazon.ion.IonSymbol;
 import com.amazon.ion.IonValue;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
@@ -62,9 +65,8 @@ public class IonStructToMapObjectInspector implements MapObjectInspector {
 
         final IonStruct struct = (IonStruct) data;
         final IonSymbol symbol = (IonSymbol) key;
-        IonValue v = struct.get(symbol.stringValue());
 
-        return IonUtil.isIonNull(v) ? null : v;
+        return IonUtil.handleNull(struct.get(symbol.stringValue()));
     }
 
     @Override
@@ -75,21 +77,8 @@ public class IonStructToMapObjectInspector implements MapObjectInspector {
 
         final IonStruct struct = (IonStruct) data;
 
-        // sets the initial size of the map to avoid growing as it's immutable while using the default HashMap load
-        // factor to maintain the same collision performance
-        final int size = (int) Math.ceil(struct.size() / DEFAULT_LOAD_FACTOR);
-
-        final Map<String, IonValue> map = new HashMap<>(size, DEFAULT_LOAD_FACTOR);
-        for (IonValue v : struct) {
-            if (!IonUtil.isIonNull(v)) {
-                map.put(v.getFieldName(), v);
-            } else {
-                // Hive can't handle Ion null
-                map.put(v.getFieldName(), null);
-            }
-        }
-
-        return map;
+        return StreamSupport.stream(struct.spliterator(), false)
+                .collect(HashMap::new, (m,v) -> m.put(v.getFieldName(), IonUtil.handleNull(v)), HashMap::putAll);
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspector.java
@@ -97,7 +97,12 @@ public class IonStructToStructInspector extends StructObjectInspector {
 
         List<Object> list = new ArrayList<>(struct.size());
         for (IonValue v : struct) {
-            list.add(v);
+            if (!IonUtil.isIonNull(v)) {
+                list.add(v);
+            } else {
+                // Hive can't handle Ion null
+                list.add(null);
+            }
         }
 
         return list;

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspector.java
@@ -83,8 +83,9 @@ public class IonStructToStructInspector extends StructObjectInspector {
         }
 
         final IonStruct struct = (IonStruct) data;
+        IonValue v = struct.get(fieldRef.getFieldName());
 
-        return struct.get(fieldRef.getFieldName());
+        return isIonNull(v) ? null : v;
     }
 
     @Override

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonUtil.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonUtil.java
@@ -26,7 +26,7 @@ public class IonUtil {
         return ionValue == null || ionValue.isNullValue();
     }
 
-    public static <T extends IonValue> T handleNull(T value) {
+    public static <T extends IonValue> T handleNull(final T value) {
         return isIonNull(value) ? null : value;
     }
 }

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonUtil.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonUtil.java
@@ -25,4 +25,8 @@ public class IonUtil {
     static boolean isIonNull(final IonValue ionValue) {
         return ionValue == null || ionValue.isNullValue();
     }
+
+    public static <T extends IonValue> T handleNull(T value) {
+        return isIonNull(value) ? null : value;
+    }
 }

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/Util.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/Util.kt
@@ -15,7 +15,53 @@
 
 package com.amazon.ionhiveserde
 
+import com.amazon.ion.IonDatagram
+import com.amazon.ion.IonSequence
+import com.amazon.ion.IonStruct
 import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensitiveDecorator
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
 
 internal val ION = IonSystemBuilder.standard().build()
 internal val ionNull = ION.newNull()
+
+internal fun datagram_for(s: String): IonDatagram {
+    return ION.loader.load(s)
+}
+
+internal fun struct_for(s: String): IonStruct {
+    val v = datagram_for(s).iterator().next()
+    if (v !is IonStruct) throw IllegalArgumentException("Required an IonStruct, found ${v.javaClass.simpleName}")
+
+    return v
+}
+
+internal fun case_insensitive_decorator_struct_for(s : String): IonStruct {
+    return IonStructCaseInsensitiveDecorator(struct_for(s))
+}
+
+internal fun sequence_for(s: String): IonSequence {
+    val v = datagram_for(s).iterator().next()
+    if (v !is IonSequence) throw IllegalArgumentException("Required an IonSequence, found ${v.javaClass.simpleName}")
+
+    return v
+}
+
+internal fun case_insensitive_decorator_sequence_for(s : String): IonSequence {
+    return IonSequenceCaseInsensitiveDecorator(sequence_for(s))
+}
+
+/**
+ * Create a sample struct used for testing. To create a desired Ion struct, use struct_for().
+ */
+internal fun makeStruct(): IonStruct {
+    return struct_for("{a: 1, b: 2, c: 3}")
+}
+
+/**
+ * Create a sample case insensitive struct used for testing. To create a desired case insensitive Ion struct,
+ * use case_insensitive_decorator_struct_for().
+ */
+internal fun makeCaseInsensitiveStruct(): IonStruct {
+    return case_insensitive_decorator_struct_for("{a: 1, b: null}")
+}

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/Util.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/Util.kt
@@ -18,9 +18,9 @@ package com.amazon.ionhiveserde
 import com.amazon.ion.IonDatagram
 import com.amazon.ion.IonSequence
 import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
-import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensitiveDecorator
-import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonCaseInsensitiveDecorator
 
 internal val ION = IonSystemBuilder.standard().build()
 internal val ionNull = ION.newNull()
@@ -36,10 +36,6 @@ internal fun struct_for(s: String): IonStruct {
     return v
 }
 
-internal fun case_insensitive_decorator_struct_for(s : String): IonStruct {
-    return IonStructCaseInsensitiveDecorator(struct_for(s))
-}
-
 internal fun sequence_for(s: String): IonSequence {
     val v = datagram_for(s).iterator().next()
     if (v !is IonSequence) throw IllegalArgumentException("Required an IonSequence, found ${v.javaClass.simpleName}")
@@ -47,21 +43,7 @@ internal fun sequence_for(s: String): IonSequence {
     return v
 }
 
-internal fun case_insensitive_decorator_sequence_for(s : String): IonSequence {
-    return IonSequenceCaseInsensitiveDecorator(sequence_for(s))
+internal fun case_insensitive(v: IonValue): IonValue {
+    return IonCaseInsensitiveDecorator.wrapValue(v)
 }
 
-/**
- * Create a sample struct used for testing. To create a desired Ion struct, use struct_for().
- */
-internal fun makeStruct(): IonStruct {
-    return struct_for("{a: 1, b: 2, c: 3}")
-}
-
-/**
- * Create a sample case insensitive struct used for testing. To create a desired case insensitive Ion struct,
- * use case_insensitive_decorator_struct_for().
- */
-internal fun makeCaseInsensitiveStruct(): IonStruct {
-    return case_insensitive_decorator_struct_for("{a: 1, b: null}")
-}

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -15,71 +15,48 @@
 
 package com.amazon.ionhiveserde.configuration
 
-import com.amazon.ion.*
+import com.amazon.ion.IonValue
+import com.amazon.ionhiveserde.*
 import com.amazon.ionhiveserde.ION
-import com.amazon.ionhiveserde.assertMultiEquals
-import com.amazon.ionhiveserde.assertSequenceWrapper
-import com.amazon.ionhiveserde.assertStructWrapper
-import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensitiveDecorator
-import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 class CaseInsensitiveDecoratorTest {
-    private fun datagram_for(s: String): IonDatagram {
-        return ION.loader.load(s)
-    }
-
-    private fun struct_for(s: String): IonStruct {
-        val v = datagram_for(s).iterator().next()
-        if (v !is IonStruct) throw IllegalArgumentException("Required an IonStruct, found ${v.javaClass.simpleName}")
-
-        return IonStructCaseInsensitiveDecorator(v)
-    }
-
-    private fun sequence_for(s: String): IonSequence {
-        val v = datagram_for(s).iterator().next()
-        if (v !is IonSequence) throw IllegalArgumentException("Required an IonSequence, found ${v.javaClass.simpleName}")
-
-        return IonSequenceCaseInsensitiveDecorator(v)
-    }
-
     @Test
     fun ionStructCaseInsensitiveDecoratorContainsKey() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         assertEquals(struct.containsKey("foo"), true)
         assertEquals(struct.containsKey("bar"), false)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetExist() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         assertEquals(struct.containsKey("Foo"), true)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetNotExist() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         assertEquals(struct.containsKey("bar"), false)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetIgnoreCase() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         assertEquals(struct.containsKey("foO"), true)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetRepeatedFieldFound() {
-        val struct = struct_for(" { Foo: 'Bar', foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'Bar', foo: 'bar'}")
         assertEquals(struct.get("Foo"), ION.newSymbol("Bar"))
         assertEquals(struct.get("foo"), ION.newSymbol("bar"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetRepeatedFieldFoundIgnoringCase() {
-        val struct = struct_for(" { Foo: 'Bar', foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'Bar', foo: 'bar'}")
         assertMultiEquals(
                 arrayOf(ION.newSymbol("Bar") as IonValue, ION.newSymbol("bar") as IonValue),
                 struct.get("FOO"))
@@ -87,19 +64,19 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetStruct() {
-        val struct = struct_for(" { Foo: {} }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: {}}")
         assertStructWrapper(struct.get("Foo"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetSequence() {
-        val struct = struct_for(" { Foo: [] }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: []}")
         assertSequenceWrapper(struct.get("Foo"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemove() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         val s = struct.remove("Foo")
 
         assertEquals(0, struct.size())
@@ -108,21 +85,21 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemoveStruct() {
-        val struct = struct_for(" { Foo: {} }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: {}}")
         val s = struct.remove("Foo")
         assertStructWrapper(s)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemoveSequence() {
-        val struct = struct_for("{ Foo: [] }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: []}")
         val s = struct.remove("Foo")
         assertSequenceWrapper(s)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRemove() {
-        val struct = struct_for(" {Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{Foo: 'bar'}")
         val s = struct.cloneAndRemove("Foo")
 
         assertEquals(s.size(), 0)
@@ -131,7 +108,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRetain() {
-        val struct = struct_for("{ Foo: 'bar' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
         val s = struct.cloneAndRetain("Foo")
 
         assertEquals(s.size(), 1)
@@ -141,7 +118,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorIteratorNext() {
-        val struct = struct_for("{ Foo: 1, Bar: '2' }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: 1, Bar: '2' }")
         val iter = struct.iterator()
         val foo = iter.next()
         assertEquals(foo, ION.newInt(1))
@@ -151,7 +128,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorIteratorNull() {
-        val struct = struct_for(" { Foo: null }")
+        val struct = case_insensitive_decorator_struct_for("{ Foo: null }")
         val iter = struct.iterator()
         val v = iter.next()
         // Returns Ion null like what Ion container does
@@ -160,25 +137,25 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGet() {
-        val sequence = sequence_for("[1, '2']")
+        val sequence = case_insensitive_decorator_sequence_for("[1, '2']")
         assertEquals(sequence[1], ION.newSymbol("2"))
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGetStruct() {
-        val sequence = sequence_for("[{}]")
+        val sequence = case_insensitive_decorator_sequence_for("[{}]")
         assertStructWrapper(sequence[0])
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGetSequence() {
-        val sequence = sequence_for("[[]]")
+        val sequence = case_insensitive_decorator_sequence_for("[[]]")
         assertSequenceWrapper(sequence[0])
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSet() {
-        val sequence = sequence_for("[1]")
+        val sequence = case_insensitive_decorator_sequence_for("[1]")
         val l = sequence.set(0, ION.newInt(2))
 
         assertEquals(sequence[0], ION.newInt(2))
@@ -187,21 +164,21 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSetStruct() {
-        val sequence = sequence_for("[{}]")
+        val sequence = case_insensitive_decorator_sequence_for("[{}]")
         val l = sequence.set(0, ION.newInt(2))
         assertStructWrapper(l)
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSetSequence() {
-        val sequence = sequence_for("[[]]")
+        val sequence = case_insensitive_decorator_sequence_for("[[]]")
         val l = sequence.set(0, ION.newInt(2))
         assertSequenceWrapper(l)
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemove() {
-        val sequence = sequence_for("[1]")
+        val sequence = case_insensitive_decorator_sequence_for("[1]")
         val l = sequence.removeAt(0)
 
         assertEquals(sequence.size, 0)
@@ -210,7 +187,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemoveStruct() {
-        val sequence = sequence_for("[{}]")
+        val sequence = case_insensitive_decorator_sequence_for("[{}]")
         val l = sequence.removeAt(0)
 
         assertStructWrapper(l)
@@ -218,7 +195,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemoveSequence() {
-        val sequence = sequence_for("[[]]")
+        val sequence = case_insensitive_decorator_sequence_for("[[]]")
         val l = sequence.removeAt(0)
 
         assertSequenceWrapper(l)
@@ -226,7 +203,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorListIterator() {
-        val sequence = sequence_for("[1, [], {}]")
+        val sequence = case_insensitive_decorator_sequence_for("[1, [], {}]")
         val iter = sequence.listIterator()
         assertEquals(iter.next(), ION.newInt(1))
         val i = iter.next()
@@ -237,7 +214,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSublist() {
-        val sequence = sequence_for("[1, [], {}]")
+        val sequence = case_insensitive_decorator_sequence_for("[1, [], {}]")
         val sublist = sequence.subList(0, 3)
         // sublist: [1, [], {}]
         assertEquals(sublist[0], ION.newInt(1))
@@ -247,7 +224,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorIteratorNext() {
-        val sequence = sequence_for("[1, '2']")
+        val sequence = case_insensitive_decorator_sequence_for("[1, '2']")
         val iter = sequence.iterator()
         assertEquals(iter.next(), ION.newInt(1))
         assertEquals(iter.next(), ION.newSymbol("2"))
@@ -256,7 +233,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorIteratorNull() {
-        val sequence = sequence_for("[ null ]")
+        val sequence = case_insensitive_decorator_sequence_for("[ null ]")
         val iter = sequence.iterator()
         val v = iter.next()
         // Returns Ion null like what Ion container does

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -249,10 +249,8 @@ class CaseInsensitiveDecoratorTest {
     fun ionSequenceCaseInsensitiveDecoratorIteratorNext() {
         val sequence = sequence_for("[1, '2']")
         val iter = sequence.iterator()
-        val foo = iter.next()
-        assertEquals(foo, ION.newInt(1))
-        val bar = iter.next()
-        assertEquals(bar, ION.newSymbol("2"))
+        assertEquals(iter.next(), ION.newInt(1))
+        assertEquals(iter.next(), ION.newSymbol("2"))
     }
 
 

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -141,7 +141,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorIteratorNext() {
-        val struct = struct_for(" { Foo: 1, Bar: '2'}")
+        val struct = struct_for("{ Foo: 1, Bar: '2' }")
         val iter = struct.iterator()
         val foo = iter.next()
         assertEquals(foo, ION.newInt(1))

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -24,6 +24,7 @@ import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensiti
 import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class CaseInsensitiveDecoratorTest {
     private fun datagram_for(s: String): IonDatagram {
@@ -114,14 +115,14 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemoveSequence() {
-        val struct = struct_for(" { Foo: [] }")
+        val struct = struct_for("{ Foo: [] }")
         val s = struct.remove("Foo")
         assertSequenceWrapper(s)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRemove() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = struct_for(" {Foo: 'bar' }")
         val s = struct.cloneAndRemove("Foo")
 
         assertEquals(s.size(), 0)
@@ -130,12 +131,31 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRetain() {
-        val struct = struct_for(" { Foo: 'bar' }")
+        val struct = struct_for("{ Foo: 'bar' }")
         val s = struct.cloneAndRetain("Foo")
 
         assertEquals(s.size(), 1)
         assertEquals(s.containsKey("foo"), true)
         assertStructWrapper(s)
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorIteratorNext() {
+        val struct = struct_for(" { Foo: 1, Bar: '2'}")
+        val iter = struct.iterator()
+        val foo = iter.next()
+        assertEquals(foo, ION.newInt(1))
+        val bar = iter.next()
+        assertEquals(bar, ION.newSymbol("2"))
+    }
+
+    @Test
+    fun ionStructCaseInsensitiveDecoratorIteratorNull() {
+        val struct = struct_for(" { Foo: null }")
+        val iter = struct.iterator()
+        val v = iter.next()
+        // Returns Ion null like what Ion container does
+        assertEquals(v, ION.newNull())
     }
 
     @Test
@@ -223,5 +243,25 @@ class CaseInsensitiveDecoratorTest {
         assertEquals(sublist[0], ION.newInt(1))
         assertSequenceWrapper(sublist[1])
         assertStructWrapper(sublist[2])
+    }
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorIteratorNext() {
+        val sequence = sequence_for("[1, '2']")
+        val iter = sequence.iterator()
+        val foo = iter.next()
+        assertEquals(foo, ION.newInt(1))
+        val bar = iter.next()
+        assertEquals(bar, ION.newSymbol("2"))
+    }
+
+
+    @Test
+    fun ionSequenceCaseInsensitiveDecoratorIteratorNull() {
+        val sequence = sequence_for("[ null ]")
+        val iter = sequence.iterator()
+        val v = iter.next()
+        // Returns Ion null like what Ion container does
+        assertEquals(v, ION.newNull());
     }
 }

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/configuration/CaseInsensitiveDecoratorTest.kt
@@ -18,45 +18,47 @@ package com.amazon.ionhiveserde.configuration
 import com.amazon.ion.IonValue
 import com.amazon.ionhiveserde.*
 import com.amazon.ionhiveserde.ION
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonSequenceCaseInsensitiveDecorator
+import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class CaseInsensitiveDecoratorTest {
     @Test
     fun ionStructCaseInsensitiveDecoratorContainsKey() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertEquals(struct.containsKey("foo"), true)
         assertEquals(struct.containsKey("bar"), false)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetExist() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertEquals(struct.containsKey("Foo"), true)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetNotExist() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertEquals(struct.containsKey("bar"), false)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetIgnoreCase() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertEquals(struct.containsKey("foO"), true)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetRepeatedFieldFound() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'Bar', foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'Bar', foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertEquals(struct.get("Foo"), ION.newSymbol("Bar"))
         assertEquals(struct.get("foo"), ION.newSymbol("bar"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetRepeatedFieldFoundIgnoringCase() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'Bar', foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'Bar', foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         assertMultiEquals(
                 arrayOf(ION.newSymbol("Bar") as IonValue, ION.newSymbol("bar") as IonValue),
                 struct.get("FOO"))
@@ -64,19 +66,19 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetStruct() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: {}}")
+        val struct = case_insensitive(struct_for("{Foo: {}}")) as IonStructCaseInsensitiveDecorator
         assertStructWrapper(struct.get("Foo"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorGetSequence() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: []}")
+        val struct = case_insensitive(struct_for("{ Foo: []}")) as IonStructCaseInsensitiveDecorator
         assertSequenceWrapper(struct.get("Foo"))
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemove() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         val s = struct.remove("Foo")
 
         assertEquals(0, struct.size())
@@ -85,21 +87,21 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemoveStruct() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: {}}")
+        val struct = case_insensitive(struct_for("{Foo: {}}")) as IonStructCaseInsensitiveDecorator
         val s = struct.remove("Foo")
         assertStructWrapper(s)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorRemoveSequence() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: []}")
+        val struct = case_insensitive(struct_for("{Foo: []}")) as IonStructCaseInsensitiveDecorator
         val s = struct.remove("Foo")
         assertSequenceWrapper(s)
     }
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRemove() {
-        val struct = case_insensitive_decorator_struct_for("{Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         val s = struct.cloneAndRemove("Foo")
 
         assertEquals(s.size(), 0)
@@ -108,7 +110,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorCloneAndRetain() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 'bar'}")
+        val struct = case_insensitive(struct_for("{Foo: 'bar'}")) as IonStructCaseInsensitiveDecorator
         val s = struct.cloneAndRetain("Foo")
 
         assertEquals(s.size(), 1)
@@ -118,7 +120,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorIteratorNext() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: 1, Bar: '2' }")
+        val struct = case_insensitive(struct_for("{Foo: 1, Bar: '2'}")) as IonStructCaseInsensitiveDecorator
         val iter = struct.iterator()
         val foo = iter.next()
         assertEquals(foo, ION.newInt(1))
@@ -128,7 +130,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionStructCaseInsensitiveDecoratorIteratorNull() {
-        val struct = case_insensitive_decorator_struct_for("{ Foo: null }")
+        val struct = case_insensitive(struct_for("{Foo: null}")) as IonStructCaseInsensitiveDecorator
         val iter = struct.iterator()
         val v = iter.next()
         // Returns Ion null like what Ion container does
@@ -137,25 +139,25 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGet() {
-        val sequence = case_insensitive_decorator_sequence_for("[1, '2']")
+        val sequence = case_insensitive(sequence_for("[1, '2']")) as IonSequenceCaseInsensitiveDecorator
         assertEquals(sequence[1], ION.newSymbol("2"))
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGetStruct() {
-        val sequence = case_insensitive_decorator_sequence_for("[{}]")
+        val sequence = case_insensitive(sequence_for("[{}]")) as IonSequenceCaseInsensitiveDecorator
         assertStructWrapper(sequence[0])
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorGetSequence() {
-        val sequence = case_insensitive_decorator_sequence_for("[[]]")
+        val sequence = case_insensitive(sequence_for("[[]]")) as IonSequenceCaseInsensitiveDecorator
         assertSequenceWrapper(sequence[0])
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSet() {
-        val sequence = case_insensitive_decorator_sequence_for("[1]")
+        val sequence = case_insensitive(sequence_for("[1]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.set(0, ION.newInt(2))
 
         assertEquals(sequence[0], ION.newInt(2))
@@ -164,21 +166,21 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSetStruct() {
-        val sequence = case_insensitive_decorator_sequence_for("[{}]")
+        val sequence = case_insensitive(sequence_for("[{}]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.set(0, ION.newInt(2))
         assertStructWrapper(l)
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSetSequence() {
-        val sequence = case_insensitive_decorator_sequence_for("[[]]")
+        val sequence = case_insensitive(sequence_for("[[]]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.set(0, ION.newInt(2))
         assertSequenceWrapper(l)
     }
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemove() {
-        val sequence = case_insensitive_decorator_sequence_for("[1]")
+        val sequence = case_insensitive(sequence_for("[1]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.removeAt(0)
 
         assertEquals(sequence.size, 0)
@@ -187,7 +189,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemoveStruct() {
-        val sequence = case_insensitive_decorator_sequence_for("[{}]")
+        val sequence = case_insensitive(sequence_for("[{}]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.removeAt(0)
 
         assertStructWrapper(l)
@@ -195,7 +197,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorRemoveSequence() {
-        val sequence = case_insensitive_decorator_sequence_for("[[]]")
+        val sequence = case_insensitive(sequence_for("[[]]")) as IonSequenceCaseInsensitiveDecorator
         val l = sequence.removeAt(0)
 
         assertSequenceWrapper(l)
@@ -203,7 +205,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorListIterator() {
-        val sequence = case_insensitive_decorator_sequence_for("[1, [], {}]")
+        val sequence = case_insensitive(sequence_for("[1, [], {}]")) as IonSequenceCaseInsensitiveDecorator
         val iter = sequence.listIterator()
         assertEquals(iter.next(), ION.newInt(1))
         val i = iter.next()
@@ -214,7 +216,7 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorSublist() {
-        val sequence = case_insensitive_decorator_sequence_for("[1, [], {}]")
+        val sequence = case_insensitive(sequence_for("[1, [], {}]")) as IonSequenceCaseInsensitiveDecorator
         val sublist = sequence.subList(0, 3)
         // sublist: [1, [], {}]
         assertEquals(sublist[0], ION.newInt(1))
@@ -224,16 +226,15 @@ class CaseInsensitiveDecoratorTest {
 
     @Test
     fun ionSequenceCaseInsensitiveDecoratorIteratorNext() {
-        val sequence = case_insensitive_decorator_sequence_for("[1, '2']")
+        val sequence = case_insensitive(sequence_for("[1, '2']")) as IonSequenceCaseInsensitiveDecorator
         val iter = sequence.iterator()
         assertEquals(iter.next(), ION.newInt(1))
         assertEquals(iter.next(), ION.newSymbol("2"))
     }
 
-
     @Test
     fun ionSequenceCaseInsensitiveDecoratorIteratorNull() {
-        val sequence = case_insensitive_decorator_sequence_for("[ null ]")
+        val sequence = case_insensitive(sequence_for("[null]")) as IonSequenceCaseInsensitiveDecorator
         val iter = sequence.iterator()
         val v = iter.next()
         // Returns Ion null like what Ion container does

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspectorTest.kt
@@ -52,7 +52,7 @@ class IonSequenceToListObjectInspectorTest {
     fun getListElement(sequence: IonSequence) {
         assertEquals(ION.newInt(1), subject.getListElement(sequence, 0))
         assertEquals(ION.newInt(2), subject.getListElement(sequence, 1))
-        assertEquals(ION.newNullInt(), subject.getListElement(sequence, 2))
+        assertEquals(null, subject.getListElement(sequence, 2))
 
         assertNull(subject.getListElement(sequence, 4))
         assertNull(subject.getListElement(sequence, -1))

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonSequenceToListObjectInspectorTest.kt
@@ -43,7 +43,7 @@ class IonSequenceToListObjectInspectorTest {
             arrayOf(ION.newEmptyList(), ION.newEmptySexp()).map {
                 it.add(ION.newInt(1))
                 it.add(ION.newInt(2))
-                it.add(ION.newInt(3))
+                it.add(ION.newNullInt())
                 it
             }.toTypedArray()
 
@@ -52,7 +52,7 @@ class IonSequenceToListObjectInspectorTest {
     fun getListElement(sequence: IonSequence) {
         assertEquals(ION.newInt(1), subject.getListElement(sequence, 0))
         assertEquals(ION.newInt(2), subject.getListElement(sequence, 1))
-        assertEquals(ION.newInt(3), subject.getListElement(sequence, 2))
+        assertEquals(ION.newNullInt(), subject.getListElement(sequence, 2))
 
         assertNull(subject.getListElement(sequence, 4))
         assertNull(subject.getListElement(sequence, -1))
@@ -79,7 +79,11 @@ class IonSequenceToListObjectInspectorTest {
     @Parameters(named = "sequences")
     fun getList(sequence: IonSequence) {
         val actual = subject.getList(sequence)
-        assertEquals(sequence, actual)
+        // We should make sure the null value is inside the list returned by getList()
+        assertEquals(3, actual.size)
+        assertEquals(ION.newInt(1), actual[0])
+        assertEquals(ION.newInt(2), actual[1])
+        assertEquals(null, actual[2])
     }
 
     @Test

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -70,7 +70,7 @@ class IonStructToMapObjectInspectorTest {
         val struct = struct_for("{a: 1, b: 2, c: null}")
         val actual = subject.getMap(struct)
 
-        // We should make sure the null value is inside the map returned from getMap()
+        // We should make sure the null value is inside the map returned by getMap()
         assertEquals(3, actual.size)
 
         assertEquals(ION.newInt(1), actual["a"])
@@ -88,7 +88,7 @@ class IonStructToMapObjectInspectorTest {
         val struct = case_insensitive(struct_for("{a: 1, b: null}"))
         val actual = subject.getMap(struct)
 
-        // We should make sure the null value is inside the map returned from getMap()
+        // We should make sure the null value is inside the map returned by getMap()
         assertEquals(2, actual.size)
 
         assertEquals(ION.newInt(1), actual["a"])

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -15,10 +15,10 @@
 
 package com.amazon.ionhiveserde.objectinspectors
 
-import com.amazon.ion.IonStruct
 import com.amazon.ionhiveserde.ION
-import com.amazon.ionhiveserde.caseinsensitivedecorator.IonStructCaseInsensitiveDecorator
 import com.amazon.ionhiveserde.ionNull
+import com.amazon.ionhiveserde.makeCaseInsensitiveStruct
+import com.amazon.ionhiveserde.makeStruct
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
 import org.junit.Test
@@ -110,25 +110,5 @@ class IonStructToMapObjectInspectorTest {
     @Test
     fun getCategory() {
         assertEquals(MAP, subject.category)
-    }
-
-    private fun makeStruct(): IonStruct {
-        val struct = ION.newEmptyStruct()
-
-        struct.add("a", ION.newInt(1))
-        struct.add("b", ION.newInt(2))
-        struct.add("c", ION.newInt(3))
-
-        return struct
-    }
-
-    private fun makeCaseInsensitiveStruct(): IonStruct {
-        val rawStruct = ION.newEmptyStruct()
-        val struct = IonStructCaseInsensitiveDecorator(rawStruct)
-
-        struct.add("a", ION.newInt(1))
-        struct.add("b", ION.newNull())
-
-        return struct
     }
 }

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -41,11 +41,11 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapValueElement() {
-        val struct = struct_for("{a: 1, b: 2, c: 3}")
+        val struct = struct_for("{a: 1, b: 2, c: null}")
 
         assertEquals(ION.newInt(1), subject.getMapValueElement(struct, ION.newSymbol("a")))
         assertEquals(ION.newInt(2), subject.getMapValueElement(struct, ION.newSymbol("b")))
-        assertEquals(ION.newInt(3), subject.getMapValueElement(struct, ION.newSymbol("c")))
+        assertEquals(null, subject.getMapValueElement(struct, ION.newSymbol("c")))
         assertNull(subject.getMapValueElement(struct, ION.newSymbol("d")))
     }
 

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -16,9 +16,9 @@
 package com.amazon.ionhiveserde.objectinspectors
 
 import com.amazon.ionhiveserde.ION
+import com.amazon.ionhiveserde.case_insensitive
 import com.amazon.ionhiveserde.ionNull
-import com.amazon.ionhiveserde.makeCaseInsensitiveStruct
-import com.amazon.ionhiveserde.makeStruct
+import com.amazon.ionhiveserde.struct_for
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.MAP
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory
 import org.junit.Test
@@ -41,7 +41,7 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapValueElement() {
-        val struct = makeStruct()
+        val struct = struct_for("{a: 1, b: 2, c: 3}")
 
         assertEquals(ION.newInt(1), subject.getMapValueElement(struct, ION.newSymbol("a")))
         assertEquals(ION.newInt(2), subject.getMapValueElement(struct, ION.newSymbol("b")))
@@ -57,17 +57,17 @@ class IonStructToMapObjectInspectorTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun getMapValueElementForNullKey() {
-        assertNull(subject.getMapValueElement(makeStruct(), null))
+        assertNull(subject.getMapValueElement(struct_for("{a: 1, b: 2, c: 3}"), null))
     }
 
     @Test
     fun getMapSize() {
-        assertEquals(3, subject.getMapSize(makeStruct()))
+        assertEquals(3, subject.getMapSize(struct_for("{a: 1, b: 2, c: 3}")))
     }
 
     @Test
     fun getMap() {
-        val struct = makeStruct()
+        val struct = struct_for("{a: 1, b: 2, c: 3}")
         val actual = subject.getMap(struct)
 
         assertEquals(ION.newInt(1), actual["a"])
@@ -77,16 +77,15 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapSizeForCaseInsensitiveDecorator() {
-        assertEquals(2, subject.getMapSize(makeCaseInsensitiveStruct()))
+        assertEquals(2, subject.getMapSize(case_insensitive(struct_for("{a: 1, b: null}"))))
     }
 
     @Test
     fun getMapForCaseInsensitiveDecorator() {
-        val struct = makeCaseInsensitiveStruct()
+        val struct = case_insensitive(struct_for("{a: 1, b: null}"))
         val actual = subject.getMap(struct)
 
         assertEquals(ION.newInt(1), actual["a"])
-        // Ion null should be treated as null here as Hive doesn't know how to parse Ion null
         assertEquals(null, actual["b"])
     }
 

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -75,12 +75,9 @@ class IonStructToMapObjectInspectorTest {
         assertEquals(ION.newInt(3), actual["c"])
     }
 
-    /**
-     * The map size should be 1; The Ion null should be removed when convert Ion struct to Map.
-     */
     @Test
     fun getMapSizeForCaseInsensitiveDecorator() {
-        assertEquals(1, subject.getMapSize(makeCaseInsensitiveStruct()))
+        assertEquals(2, subject.getMapSize(makeCaseInsensitiveStruct()))
     }
 
     @Test

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspectorTest.kt
@@ -62,17 +62,20 @@ class IonStructToMapObjectInspectorTest {
 
     @Test
     fun getMapSize() {
-        assertEquals(3, subject.getMapSize(struct_for("{a: 1, b: 2, c: 3}")))
+        assertEquals(3, subject.getMapSize(struct_for("{a: 1, b: 2, c: null}")))
     }
 
     @Test
     fun getMap() {
-        val struct = struct_for("{a: 1, b: 2, c: 3}")
+        val struct = struct_for("{a: 1, b: 2, c: null}")
         val actual = subject.getMap(struct)
+
+        // We should make sure the null value is inside the map returned from getMap()
+        assertEquals(3, actual.size)
 
         assertEquals(ION.newInt(1), actual["a"])
         assertEquals(ION.newInt(2), actual["b"])
-        assertEquals(ION.newInt(3), actual["c"])
+        assertEquals(null, actual["c"])
     }
 
     @Test
@@ -84,6 +87,9 @@ class IonStructToMapObjectInspectorTest {
     fun getMapForCaseInsensitiveDecorator() {
         val struct = case_insensitive(struct_for("{a: 1, b: null}"))
         val actual = subject.getMap(struct)
+
+        // We should make sure the null value is inside the map returned from getMap()
+        assertEquals(2, actual.size)
 
         assertEquals(ION.newInt(1), actual["a"])
         assertEquals(null, actual["b"])

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonStructToStructInspectorTest.kt
@@ -17,6 +17,8 @@ package com.amazon.ionhiveserde.objectinspectors
 
 import com.amazon.ion.IonStruct
 import com.amazon.ionhiveserde.ION
+import com.amazon.ionhiveserde.case_insensitive
+import com.amazon.ionhiveserde.struct_for
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.STRUCT
 import org.apache.hadoop.hive.serde2.objectinspector.StructField
@@ -73,9 +75,22 @@ class IonStructToStructInspectorTest {
 
     @Test
     fun getStructFieldsDataAsList() {
-        val list = subject.getStructFieldsDataAsList(makeStruct())
+        val list = subject.getStructFieldsDataAsList(struct_for("{cboolean: true, cint: 1, cnull: null}"))
+        // We should make sure the null value is inside the list returned by getStructFieldsDataAsList()
+        assertEquals(3, list.size)
         assertEquals(ION.newBool(true), list[0])
         assertEquals(ION.newInt(1), list[1])
+        assertEquals(null, list[2])
+    }
+
+    @Test
+    fun getStructFieldsDataAsListForCaseInsensitiveDecorator() {
+        val list = subject.getStructFieldsDataAsList(case_insensitive(struct_for("{cboolean: true, cint: 1, cnull: null}")))
+        // We should make sure the null value is inside the list returned by getStructFieldsDataAsList()
+        assertEquals(3, list.size)
+        assertEquals(ION.newBool(true), list[0])
+        assertEquals(ION.newInt(1), list[1])
+        assertEquals(null, list[2])
     }
 
     @Test


### PR DESCRIPTION
## Description:

This PR adds a null check for IonStructToMap object inspector to avoid NPE.

This PR is consisted of two commits, the first one ([91736de](https://github.com/amzn/ion-hive-serde/pull/91/commits/91736de6c0c65822c403af9c7c13e53643f2a329)) contains unit tests and the second one ([a226202](https://github.com/amzn/ion-hive-serde/pull/91/commits/a22620293e0ff562d2e1e1c5b9bbe198ff774db2)) includes the fix. 

## Issue:
Ion-hive-serde Struct to Map conversion throws NPE for null value. 

More specifically,  ion-path-extractor only matches the top-level container instead of Ion values within the nested container with default configuration. So the null values within the nested container are not filtered and are still treated as Ion null other than primitive null as we expect [here](https://github.com/amzn/ion-hive-serde/blob/master/serde/src/main/java/com/amazon/ionhiveserde/configuration/PathExtractionConfig.java#L72-L76) (This is kind of like the case insensitive issue we saw earlier) so that Ion case insensitive decorator will later convert it back to primitive null [here](https://github.com/amzn/ion-hive-serde/blob/hive2/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonCaseInsensitiveDecorator.java#L29-L31) when [iterate](https://github.com/amzn/ion-hive-serde/blob/hive2/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonContainerCaseInsensitiveDecorator.java#L217) the struct. Therefor [in the for loop](https://github.com/amzn/ion-hive-serde/blob/hive2/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonStructToMapObjectInspector.java#L82), null.getFieldName() throws NPE. 

## Solution in this PR
Since Hive doesn't know how to parse Ion null so we need to add primitive null to the struct. Currently, we filter Ion null in [deserializer](https://github.com/amzn/ion-hive-serde/blob/master/serde/src/main/java/com/amazon/ionhiveserde/IonHiveSerDe.java#L114) before asking object inspector to do any conversion. But object inspector should be able to detect Ion null as it passed the final Map to upper layer (E.g. presto/hive). So In this PR, I added a Null check in object inspector to make sure all values are parsed correctly. 
 
The solution follows three points below.
1. Don't change ion-path-extractor's current behavior. We may change ion-path-extractor to filter null values within a nested struct but in this PR we leave path-extractor as is.
2. To avoid any confusion, Ion container case insensitive decorator should behavior the same as regular ion container without any null check logic, specifically for iterator. When decorator's iterator encounter an Ion null, it should returns Ion null rather than null.
3. Ion object inspector should be able to check null type independently. It's ok to have other methods to filter null but object inspectors should make sure all values are validated before passing them to hive/presto.


I added null check for Ion Map to Struct, once it's addressed. I'll add null check for other struct object inspectors. 
 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
