### PR TITLE
Adds support to cast an Ion value to Hive string.

### DIFF
--- a/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonContainerCaseInsensitiveDecorator.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/caseinsensitivedecorator/IonContainerCaseInsensitiveDecorator.java
@@ -195,6 +195,11 @@ class IonContainerCaseInsensitiveDecorator implements IonContainer {
         return ionContainer.toString();
     }
 
+    @Override
+    public String toString() {
+        return ionContainer.toString();
+    }
+
     public class IteratorCaseInsensitiveDecorator implements Iterator<IonValue> {
         Iterator<IonValue> iterator;
 

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonValueToStringObjectInspector.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonValueToStringObjectInspector.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors;
+
+import com.amazon.ion.IonText;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+/**
+ * Adapts an {@link IonValue} for the string Hive type. An {@link IonText} value
+ * will be represented by its content, while a non-text {@link IonValue} will be
+ * represented by an Ion textual representation. E.g. the Ion value
+ * {@code "bar"} is an Ion string and will map to {@code "bar"}, whereas the
+ * Ion value {@code { foo: "bar" }} is an Ion struct and would map to
+ * something like {@code "{foo: \"bar\"}" } .
+ */
+public class IonValueToStringObjectInspector extends AbstractIonPrimitiveJavaObjectInspector implements
+        StringObjectInspector {
+
+    public IonValueToStringObjectInspector() {
+        super(TypeInfoFactory.stringTypeInfo);
+    }
+
+    @Override
+    public String getPrimitiveJavaObject(final Object o) {
+        if (IonUtil.isIonNull((IonValue) o)) {
+            return null;
+        }
+
+        return getPrimitiveWritableObject((IonValue) o);
+    }
+
+    @Override
+    public Text getPrimitiveWritableObject(final Object o) {
+        if (IonUtil.isIonNull((IonValue) o)) {
+            return null;
+        }
+
+        return new Text(getPrimitiveWritableObject((IonValue) o));
+    }
+
+    private String getPrimitiveWritableObject(final IonValue ionValue) {
+        if (IonType.isText(ionValue.getType())) {
+            return ((IonText) ionValue).stringValue();
+        }
+        return ionValue.toString();
+    }
+}

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
@@ -34,10 +34,10 @@ import com.amazon.ionhiveserde.objectinspectors.IonTextToVarcharObjectInspector;
 import com.amazon.ionhiveserde.objectinspectors.IonTimestampToDateObjectInspector;
 import com.amazon.ionhiveserde.objectinspectors.IonTimestampToTimestampObjectInspector;
 import com.amazon.ionhiveserde.objectinspectors.IonUnionObjectInspector;
+import com.amazon.ionhiveserde.objectinspectors.IonValueToStringObjectInspector;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amazon.ionhiveserde.objectinspectors.IonValueToStringObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;

--- a/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
+++ b/serde/src/main/java/com/amazon/ionhiveserde/objectinspectors/factories/IonObjectInspectorFactory.java
@@ -36,6 +36,8 @@ import com.amazon.ionhiveserde.objectinspectors.IonTimestampToTimestampObjectIns
 import com.amazon.ionhiveserde.objectinspectors.IonUnionObjectInspector;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.amazon.ionhiveserde.objectinspectors.IonValueToStringObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
@@ -86,6 +88,9 @@ public class IonObjectInspectorFactory {
         new IonTimestampToDateObjectInspector();
     private static final IonTimestampToTimestampObjectInspector TIMESTAMP_TO_TIMESTAMP_OBJECT_INSPECTOR =
         new IonTimestampToTimestampObjectInspector();
+    private static final IonValueToStringObjectInspector ION_VALUE_TO_STRING_OBJECT_INSPECTOR =
+            new IonValueToStringObjectInspector();
+
 
     /**
      * Creates an object inspector for the table correctly configured.
@@ -187,7 +192,7 @@ public class IonObjectInspectorFactory {
                         break;
 
                     case STRING:
-                        objectInspector = TEXT_TO_STRING_OBJECT_INSPECTOR;
+                        objectInspector = ION_VALUE_TO_STRING_OBJECT_INSPECTOR;
                         break;
 
                     case BINARY:

--- a/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonValueToStringObjectInspectorTest.kt
+++ b/serde/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonValueToStringObjectInspectorTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionhiveserde.objectinspectors
+
+import com.amazon.ion.IonType
+import com.amazon.ion.IonValue
+import com.amazon.ion.impl._Private_Utils
+import com.amazon.ionhiveserde.ION
+import org.apache.hadoop.io.Text
+
+class IonValueToStringObjectInspectorTest : AbstractIonPrimitiveJavaObjectInspectorTest<IonValue, Text, String>() {
+
+    override val subject = com.amazon.ionhiveserde.objectinspectors.IonValueToStringObjectInspector()
+    override fun validTestCases() = listOf(
+            ValidTestCase(ION.newString("some string"), "some string", Text("some string")),
+            ValidTestCase(ION.newSymbol("some string"), "some string", Text("some string")),
+            ValidTestCase(ION.newInt(12), "12", Text("12")),
+            ValidTestCase(ION.newDecimal(12.1), "12.1", Text("12.1")),
+            ValidTestCase(ION.newFloat(12345), "12345e0", Text("12345e0")),
+            ValidTestCase(ION.newBool(true), "true", Text("true")),
+            ValidTestCase(ION.newUtcTimestampFromMillis(999999999999), "2001-09-09T01:46:39.999Z", Text("2001-09-09T01:46:39.999Z")),
+            ValidTestCase(generateTestIonStruct("field", ION.newInt(1)), "{field:1}", Text("{field:1}")),
+            ValidTestCase(ION.newList(intArrayOf(1)), "[1]", Text("[1]")),
+            ValidTestCase(ION.newSexp(intArrayOf(1)), "(1)", Text("(1)")),
+            ValidTestCase(ION.newClob(_Private_Utils.utf8("test")), "{{\"test\"}}", Text("{{\"test\"}}")),
+            ValidTestCase(ION.newBlob(byteArrayOf(1, 2, 3, 4, 5)), "{{AQIDBAU=}}", Text("{{AQIDBAU=}}")),
+    )
+
+    private fun generateTestIonStruct(field: String, value: IonValue): IonValue {
+        val struct = ION.newEmptyStruct()
+        struct.add(field, value)
+        return struct
+    }
+}


### PR DESCRIPTION
This PR apply ToString fix to hive3, which had already addressed in hive2 branch. 

See https://github.com/amzn/ion-hive-serde/pull/77 for details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
