### PR TITLE
Adds coercion from IonFloat to HiveDecimal

### DIFF
--- a/buildSrc/src/main/kotlin/ion-hive-serde.dependencies.gradle.kts
+++ b/buildSrc/src/main/kotlin/ion-hive-serde.dependencies.gradle.kts
@@ -22,7 +22,7 @@ object Versions {
     val hive2_version = "[2.3.0,2.4.0)"
     val hive3_version = "[3.1.2,3.1.17)"
     val kotlin_version = "1.9.22"
-    val ionjava_version = "[1.4.0,2.0.0)"
+    val ionjava_version = "[1.9.1,2.0.0)"
     val pathextraction_version = "[1.2.0,2.0.0)"
     val hadoop_version = "[2.7.0,2.8.0)"
 }

--- a/hive-common/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonNumberToDecimalObjectInspector.java
+++ b/hive-common/src/main/java/com/amazon/ionhiveserde/objectinspectors/IonNumberToDecimalObjectInspector.java
@@ -5,8 +5,7 @@ package com.amazon.ionhiveserde.objectinspectors;
 
 import static com.amazon.ionhiveserde.objectinspectors.IonUtil.isIonNull;
 
-import com.amazon.ion.IonDecimal;
-import com.amazon.ion.IonInt;
+import com.amazon.ion.IonNumber;
 import com.amazon.ion.IonValue;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
@@ -14,7 +13,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObject
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 /**
- * Adapts an {@link IonDecimal} or {@link IonInt} for the decimal Hive type.
+ * Adapts an {@link IonNumber} for the decimal Hive type.
  */
 public class IonNumberToDecimalObjectInspector extends AbstractIonPrimitiveJavaObjectInspector implements
     HiveDecimalObjectInspector {
@@ -36,27 +35,14 @@ public class IonNumberToDecimalObjectInspector extends AbstractIonPrimitiveJavaO
     @Override
     public HiveDecimal getPrimitiveJavaObject(final Object o) {
         final IonValue value = (IonValue) o;
-        if (isIonNull((IonValue) o)) {
+        if (isIonNull(value)) {
             return null;
         }
 
-        switch (value.getType()) {
-            case INT:
-                return getPrimitiveJavaObject((IonInt) o);
-
-            case DECIMAL:
-                return getPrimitiveJavaObject((IonDecimal) o);
-
-            default:
-                throw new IllegalArgumentException("Invalid Ion type: " + value.getType());
+        if (value instanceof IonNumber) {
+            return HiveDecimal.create(((IonNumber) value).bigDecimalValue());
+        } else {
+            throw new IllegalArgumentException("Invalid Ion type: " + value.getType());
         }
-    }
-
-    private HiveDecimal getPrimitiveJavaObject(final IonDecimal ionValue) {
-        return HiveDecimal.create(ionValue.bigDecimalValue());
-    }
-
-    private HiveDecimal getPrimitiveJavaObject(final IonInt ionValue) {
-        return HiveDecimal.create(ionValue.bigIntegerValue());
     }
 }

--- a/hive-common/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonNumberToDecimalObjectInspectorTest.kt
+++ b/hive-common/src/test/kotlin/com/amazon/ionhiveserde/objectinspectors/IonNumberToDecimalObjectInspectorTest.kt
@@ -7,6 +7,9 @@ import com.amazon.ion.IonValue
 import com.amazon.ionhiveserde.ION
 import org.apache.hadoop.hive.common.type.HiveDecimal
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.NumberFormatException
 
 class IonNumberToDecimalObjectInspectorTest
     : AbstractIonPrimitiveJavaObjectInspectorTest<IonValue, HiveDecimalWritable, HiveDecimal>() {
@@ -14,9 +17,18 @@ class IonNumberToDecimalObjectInspectorTest
     override fun validTestCases() = listOf(
             ValidTestCase(ION.newDecimal(1), HiveDecimal.ONE, HiveDecimalWritable(HiveDecimal.ONE)),
             ValidTestCase(ION.newDecimal(0), HiveDecimal.ZERO, HiveDecimalWritable(HiveDecimal.ZERO)),
+            ValidTestCase(ION.newFloat(1), HiveDecimal.ONE, HiveDecimalWritable(HiveDecimal.ONE)),
+            ValidTestCase(ION.newFloat(0), HiveDecimal.ZERO, HiveDecimalWritable(HiveDecimal.ZERO)),
+            ValidTestCase(ION.newInt(1), HiveDecimal.ONE, HiveDecimalWritable(HiveDecimal.ONE)),
             ValidTestCase(ION.newInt(0), HiveDecimal.ZERO, HiveDecimalWritable(HiveDecimal.ZERO)),
-            ValidTestCase(ION.newInt(0), HiveDecimal.ZERO, HiveDecimalWritable(HiveDecimal.ZERO))
     )
+
+    @Test
+    fun `non-numeric floats cannot be converted`() {
+        assertThrows<NumberFormatException> { subject.getPrimitiveJavaObject(ION.newFloat(Double.NaN)) }
+        assertThrows<NumberFormatException> { subject.getPrimitiveJavaObject(ION.newFloat(Double.NEGATIVE_INFINITY)) }
+        assertThrows<NumberFormatException> { subject.getPrimitiveJavaObject(ION.newFloat(Double.POSITIVE_INFINITY)) }
+    }
 
     override val subject = com.amazon.ionhiveserde.objectinspectors.IonNumberToDecimalObjectInspector()
 }


### PR DESCRIPTION
**Issue #, if available:**

Fix #112 

**Description of changes:**

Adds automatic coercion from Ion Float to Hive Decimal (with the exception that a `NumberFormatException` is thrown if you try to coerce `nan`, `+inf`, or `-inf`). Also updates the minimum `ion-java` version to be the release when `bigDecimalValue` was added to the `IonNumber` interface.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
